### PR TITLE
Fix CL version specifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,22 +38,23 @@ find_package(OpenCL)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${OpenCL_INCLUDE_DIR})
 
+# This will setup the OpenCL headers and OpenCL C++ bindings to require
+# no more than OpenCL 2.1.  This means that these samples should be
+# deployable to any system that has an OpenCL 2.1 or newer ICD loader,
+# and that they should run correctly on any OpenCL 2.1 implementation.
+# Changing these defines to a newer OpenCL version will enable the new
+# OpenCL functionality, however it will also require a newer ICD loader
+# and a newer OpenCL implementation.
+add_definitions(-DCL_TARGET_OPENCL_VERSION=210)
+add_definitions(-DCL_HPP_TARGET_OPENCL_VERSION=210)
+add_definitions(-DCL_HPP_MINIMUM_OPENCL_VERSION=210)
+
 add_subdirectory(external/opencl-icd-loader)
+
 set_target_properties(icd_loader_test  PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set_target_properties(IcdLog           PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set_target_properties(OpenCL           PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set_target_properties(OpenCLDriverStub PROPERTIES FOLDER "OpenCL-ICD-Loader")
-
-# This will setup the OpenCL headers and OpenCL C++ bindings to require
-# no more than OpenCL 1.2.  This means that these samples should be
-# deployable to any system that has an OpenCL 1.2 or newer ICD loader,
-# and that they should run correctly on any OpenCL 1.2 implementation.
-# Changing these defines to a newer OpenCL version will enable the new
-# OpenCL functionality, however it will also require a newer ICD loader
-# and a newer OpenCL implementation.
-add_definitions(-DCL_TARGET_OPENCL_VERSION=120)
-add_definitions(-DCL_HPP_TARGET_OPENCL_VERSION=120)
-add_definitions(-DCL_HPP_MINIMUM_OPENCL_VERSION=120)
 
 add_subdirectory(samples)
 


### PR DESCRIPTION
Without this fix, I get a bunch of warnings during a build from source:

```
In file included from /home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl.h:32:0,
                 from /home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl_gl.h:32,
                 from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/test/driver_stub/cl_gl.c:1:
/home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
 #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
         ^~~~~~~
In file included from /home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl.h:32:0,
                 from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/test/driver_stub/cl_ext.c:4:
/home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
 #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
         ^~~~~~~
In file included from /home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl.h:32:0,
                 from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/test/driver_stub/cl.c:17:
/home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
 #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
         ^~~~~~~
In file included from /home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl.h:32:0,
                 from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/test/driver_stub/icd.c:15:
/home/caleb/src/SimpleOpenCLSamples/external/OpenCL-Headers/CL/cl_version.h:34:9: note: #pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)
 #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220 (OpenCL 2.2)")
```

After fixing this, I also had to update the version specifier from 1.2 to 2.1 to prevent the following build errors:

```
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:141:11: error: unknown type name ‘cl_queue_properties’
     const cl_queue_properties * /* properties */,
           ^~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:204:11: error: unknown type name ‘cl_pipe_properties’
     const cl_pipe_properties * /* properties */,
           ^~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:209:5: error: unknown type name ‘cl_pipe_info’; did you mean ‘cl_image_info’?
     cl_pipe_info /* param_name */,
     ^~~~~~~~~~~~
     cl_image_info
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:216:5: error: unknown type name ‘cl_svm_mem_flags’; did you mean ‘cl_svm_mem_flags_arm’?
     cl_svm_mem_flags /* flags */,
     ^~~~~~~~~~~~~~~~
     cl_svm_mem_flags_arm
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:245:11: error: unknown type name ‘cl_sampler_properties’
     const cl_sampler_properties * /* sampler_properties */,
           ^~~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:387:5: error: unknown type name ‘cl_kernel_exec_info’; did you mean ‘cl_kernel_exec_info_arm’?
     cl_kernel_exec_info  /* param_name */,
     ^~~~~~~~~~~~~~~~~~~
     cl_kernel_exec_info_arm
In file included from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd.c:20:0:
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:141:11: error: unknown type name ‘cl_queue_properties’
     const cl_queue_properties * /* properties */,
           ^~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:204:11: error: unknown type name ‘cl_pipe_properties’
     const cl_pipe_properties * /* properties */,
           ^~~~~~~~~~~~~~~~~~
In file included from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:19:0:
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:1430:5: error: unknown type name ‘KHRpfn_clGetPipeInfo’
     KHRpfn_clGetPipeInfo                            clGetPipeInfo;
     ^~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:1431:5: error: unknown type name ‘KHRpfn_clSVMAlloc’
     KHRpfn_clSVMAlloc                               clSVMAlloc;
     ^~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:1440:5: error: unknown type name ‘KHRpfn_clSetKernelExecInfo’
     KHRpfn_clSetKernelExecInfo                      clSetKernelExecInfo;
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:209:5: error: unknown type name ‘cl_pipe_info’; did you mean ‘cl_image_info’?
     cl_pipe_info /* param_name */,
     ^~~~~~~~~~~~
     cl_image_info
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:216:5: error: unknown type name ‘cl_svm_mem_flags’; did you mean ‘cl_svm_mem_flags_arm’?
     cl_svm_mem_flags /* flags */,
     ^~~~~~~~~~~~~~~~
     cl_svm_mem_flags_arm
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:245:11: error: unknown type name ‘cl_sampler_properties’
     const cl_sampler_properties * /* sampler_properties */,
           ^~~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:387:5: error: unknown type name ‘cl_kernel_exec_info’; did you mean ‘cl_kernel_exec_info_arm’?
     cl_kernel_exec_info  /* param_name */,
     ^~~~~~~~~~~~~~~~~~~
     cl_kernel_exec_info_arm
In file included from /home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd.c:20:0:
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:1430:5: error: unknown type name ‘KHRpfn_clGetPipeInfo’
     KHRpfn_clGetPipeInfo                            clGetPipeInfo;
     ^~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:1431:5: error: unknown type name ‘KHRpfn_clSVMAlloc’
     KHRpfn_clSVMAlloc                               clSVMAlloc;
     ^~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.h:1440:5: error: unknown type name ‘KHRpfn_clSetKernelExecInfo’
     KHRpfn_clSetKernelExecInfo                      clSetKernelExecInfo;
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:2309:11: error: unknown type name ‘cl_queue_properties’
     const cl_queue_properties * properties,
           ^~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:2326:11: error: unknown type name ‘cl_pipe_properties’
     const cl_pipe_properties * properties,
           ^~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:2342:5: error: unknown type name ‘cl_pipe_info’; did you mean ‘cl_image_info’?
     cl_pipe_info param_name,
     ^~~~~~~~~~~~
     cl_image_info
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:2359:5: error: unknown type name ‘cl_svm_mem_flags’; did you mean ‘cl_svm_mem_flags_arm’?
     cl_svm_mem_flags flags,
     ^~~~~~~~~~~~~~~~
     cl_svm_mem_flags_arm
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:2502:11: error: unknown type name ‘cl_sampler_properties’
     const cl_sampler_properties *  sampler_properties,
           ^~~~~~~~~~~~~~~~~~~~~
/home/caleb/src/SimpleOpenCLSamples/external/opencl-icd-loader/icd_dispatch.c:2528:5: error: unknown type name ‘cl_kernel_exec_info’; did you mean ‘cl_kernel_exec_info_arm’?
     cl_kernel_exec_info  param_name,
     ^~~~~~~~~~~~~~~~~~~
     cl_kernel_exec_info_arm
```
