### PR TITLE
Avoid double allocation in file

### DIFF
--- a/samples/05_spirvkernelfromfile/main.cpp
+++ b/samples/05_spirvkernelfromfile/main.cpp
@@ -45,7 +45,7 @@ static std::vector<cl_uchar> readSPIRVFromFile(
     filesize = (size_t)is.tellg();
     is.seekg(0, std::ios::beg);
 
-    ret.resize(filesize);
+    ret.reserve(filesize);
     ret.insert(
         ret.begin(),
         std::istreambuf_iterator<char>(is),


### PR DESCRIPTION
Use reserve to allocate capacity (but not fill the buffer with bytes), to avoid double allocation of the file.