### PR TITLE
only set folders for ICD loader, not for ICD loader tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${OpenCL_INCLUDE_DIR})
 
 add_subdirectory(external/opencl-icd-loader)
-set_target_properties(icd_loader_test  PROPERTIES FOLDER "OpenCL-ICD-Loader")
-set_target_properties(IcdLog           PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set_target_properties(OpenCL           PROPERTIES FOLDER "OpenCL-ICD-Loader")
-set_target_properties(OpenCLDriverStub PROPERTIES FOLDER "OpenCL-ICD-Loader")
 
 add_subdirectory(samples)
 


### PR DESCRIPTION
Since the ICD loader tests don't build by default anymore there is no need to set the folder for the ICD loader tests.