### PR TITLE
guard setProgramReleaseCallback to eliminate warning

### DIFF
--- a/include/CL/cl2.hpp
+++ b/include/CL/cl2.hpp
@@ -6813,6 +6813,7 @@ public:
     }
 
 #if CL_HPP_TARGET_OPENCL_VERSION >= 220
+#if defined(CL_USE_DEPRECATED_OPENCL_2_2_APIS)
     /*! \brief Registers a callback function to be called when destructors for
      *         program scope global variables are complete and before the
      *         program is released.
@@ -6823,9 +6824,9 @@ public:
      *  on a callback stack associated with program. The registered user callback
      *  functions are called in the reverse order in which they were registered.
      */
-    cl_int setReleaseCallback(
+    CL_EXT_PREFIX__VERSION_2_2_DEPRECATED cl_int setReleaseCallback(
         void (CL_CALLBACK * pfn_notify)(cl_program program, void * user_data),
-        void * user_data = NULL)
+        void * user_data = NULL) CL_EXT_SUFFIX__VERSION_2_2_DEPRECATED
     {
         return detail::errHandler(
             ::clSetProgramReleaseCallback(
@@ -6834,6 +6835,7 @@ public:
                 user_data),
             __SET_PROGRAM_RELEASE_CALLBACK_ERR);
     }
+#endif // #if defined(CL_USE_DEPRECATED_OPENCL_2_2_APIS)
 
     /*! \brief Sets a SPIR-V specialization constant.
      *


### PR DESCRIPTION
Temporarily add guards around calls to clSetProgramReleaseCallback to eliminate a deprecated API warning until this change is upstreamed.