### PR TITLE
add more enumimageformats image channel orders

### DIFF
--- a/samples/images/00_enumimageformats/CMakeLists.txt
+++ b/samples/images/00_enumimageformats/CMakeLists.txt
@@ -22,6 +22,6 @@ add_opencl_sample(
     TEST
     NUMBER 00
     TARGET enumimageformats
-    VERSION 120
+    VERSION 300 # for OpenCL 2.0+ image formats
     CATEGORY images
     SOURCES main.cpp)

--- a/samples/images/00_enumimageformats/main.cpp
+++ b/samples/images/00_enumimageformats/main.cpp
@@ -97,6 +97,19 @@ const char* channel_order_to_string(cl_channel_order channel_order)
     CASE_TO_STRING(CL_sBGRA);
     CASE_TO_STRING(CL_ABGR);
 #endif
+#ifdef CL_NV21_IMG  // cl_img_yuv_image
+    CASE_TO_STRING(CL_NV21_IMG);
+    CASE_TO_STRING(CL_YV12_IMG);
+#endif
+#ifdef cl_intel_packed_yuv
+    CASE_TO_STRING(CL_YUYV_INTEL);
+    CASE_TO_STRING(CL_UYVY_INTEL);
+    CASE_TO_STRING(CL_YVYU_INTEL);
+    CASE_TO_STRING(CL_VYUY_INTEL);
+#endif
+#ifdef CL_NV12_INTEL // cl_intel_planar_yuv
+    CASE_TO_STRING(CL_NV12_INTEL);
+#endif
     default: return "Unknown cl_channel_order";
     }
 }


### PR DESCRIPTION
* compile enumimageformats for OpenCL 3.0 by default to pick up OpenCL 2.0 and newer image formats
* pick up extension image formats if they are in the headers