### PR TITLE
add ND-range kernel from file sample

### DIFF
--- a/samples/06_ndrangekernelfromfile/CMakeLists.txt
+++ b/samples/06_ndrangekernelfromfile/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2019-2021 Ben Ashbaugh
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+add_opencl_sample(
+    TEST
+    NUMBER 06
+    TARGET ndrangekernelfromfile
+    VERSION 120
+    SOURCES main.cpp
+    KERNELS ndrange_sample_kernel.cl)

--- a/samples/06_ndrangekernelfromfile/README.md
+++ b/samples/06_ndrangekernelfromfile/README.md
@@ -1,0 +1,63 @@
+# ndrangekernelfromfile
+
+## Sample Purpose
+
+This is a modified version of the previous sample that loads a kernel from a file.
+The most important difference in this sample is that it specifies a "local work size".
+When enqueueing an OpenCL kernel for execution we can specify only a "global work size", describing the range of work-items that will execute the kernel, or we can specify both a "global work size" and a "local work size".
+If we specify a "local work size" this will describe how work-items are grouped into work-groups for execution.
+Work-items in a work-group are special: they're guaranteed to execute concurrently, they can exchange results via "local memory", and they can synchronize execution using barriers.
+The default kernel for this sample does not take advantage of any of these features, however future samples will!
+
+Many devices may only support "uniform" work-groups, where the local work size evenly divides the global work size.
+To check if "non-uniform" work-groups are supported, query the OpenCL version supported by the device: only "uniform" work-groups are supported for OpenCL 1.x devices, "non-uniform" work-groups are required for OpenCL 2.x devices, and optional support for non-uniform work-group support can be queried using `CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT` for OpenCL 3.0 devices.
+If non-uniform work-groups are supported, they will need to be enabled by compiling with the `-cl-std=CL2.0` or `-cl-std=CL3.0` compile, link, or build options.
+
+Additional notes:
+
+1. This sample builds and runs the kernel in the file, but does not check for specific results.
+2. To run successfully, the kernel should accept a single global memory kernel argument, and should write fewer than `gwx` 32-bit values to the kernel argument buffer.
+3. The `install` target (`make install` on Linux, or right-click on `INSTALL` and build in Visual Studio, for example) will automatically copy the kernel file to the install directory with the application directory.
+4. If the local work size `lwx` is set to zero this sample will use a `NULL` local work size, just like the previous sample.
+
+## Key APIs and Concepts
+
+This sample demonstrates how to specify groupings of work-items when enqueueing an OpenCL kernel for execution, by passing a non-NULL local work size to `clEnqueueNDRangeKernel`.
+
+This sample also supports compiling and linking the program object separately using `clCompileProgram` and `clLinkProgram` rather than performing both steps using `clBuildProgram`.
+
+```c
+clEnqueueNDRangeKernel with a non-NULL local work size
+clCompileProgram
+clLinkProgram
+```
+
+## Things to Try
+
+Here are some suggested ways to modify this sample to learn more:
+
+1. How does performance change with different local work sizes?
+What happens with a local work size equal to `1`?
+Does performance get better or worse with larger local work sizes?
+Can you find a local work size that performs better than the `NULL` local work size?
+2. Does your device support non-uniform work-groups?
+If not, what happens if you pass a local work size that does not evenly divide the global work size?
+If so, can you pass the right build options to enable non-uniform work-group support?
+3. Do you see any difference compiling and linking the program separately vs. building it in one step?
+4. Can load and compile a program from a different file and link with it?
+
+## Command Line Options
+
+| Option | Default Value | Description |
+|:--|:-:|:--|
+| `-d <index>` | 0 | Specify the index of the OpenCL device in the platform to execute on the sample on.
+| `-p <index>` | 0 | Specify the index of the OpenCL platform to execute the sample on.
+| `--file <string>` | `ndrange_sample_kernel.cl` | Specify the name of the file with the OpenCL kernel source.
+| `--name <string>` | `Test` | Specify the name of the OpenCL kernel in the source file.
+| `--options <string>` | None | Specify optional program build options.
+| `--gwx <number>` | 512 | Specify the global work size to execute.
+| `--lwx <number>` | 512 | Specify the local work size grouping.
+| `-a` | `false` | Show advanced options.
+| `-c` | `false` | (advanced) Use `clCompileProgram` and `clLinkProgram` instead of `clBuildProgram`.
+| `--compileoptions <string>` | None | (advanced) Specify optional program compile options.
+| `--linkoptions <string>` | None | (advanced) Specify optional program link options.

--- a/samples/06_ndrangekernelfromfile/README.md
+++ b/samples/06_ndrangekernelfromfile/README.md
@@ -2,15 +2,17 @@
 
 ## Sample Purpose
 
-This is a modified version of the previous sample that loads a kernel from a file.
-The most important difference in this sample is that it specifies a "local work size".
-When enqueueing an OpenCL kernel for execution we can specify only a "global work size", describing the range of work-items that will execute the kernel, or we can specify both a "global work size" and a "local work size".
-If we specify a "local work size" this will describe how work-items are grouped into work-groups for execution.
+This is a modified version of a previous sample that loads a kernel from a file.
+The most important difference between the previous sample and this sample is that this sample specifies a "local work size" when enqueueing the kernel for execution.
+
+When enqueueing an OpenCL kernel for execution, we can specify only a "global work size", describing the range of work-items that will execute the kernel, or we can specify both a "global work size" and a "local work size".
+If we specify a "local work size" then the local work size this will describe how work-items are grouped into work-groups for execution.
+
 Work-items in a work-group are special: they're guaranteed to execute concurrently, they can exchange results via "local memory", and they can synchronize execution using barriers.
 The default kernel for this sample does not take advantage of any of these features, however future samples will!
 
-Many devices may only support "uniform" work-groups, where the local work size evenly divides the global work size.
-To check if "non-uniform" work-groups are supported, query the OpenCL version supported by the device: only "uniform" work-groups are supported for OpenCL 1.x devices, "non-uniform" work-groups are required for OpenCL 2.x devices, and optional support for non-uniform work-group support can be queried using `CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT` for OpenCL 3.0 devices.
+Many devices support only "uniform" work-groups, where the local work size evenly divides the global work size.
+To check if "non-uniform" work-groups are supported, query the OpenCL version supported by the device: only "uniform" work-groups are supported for OpenCL 1.x devices, support for "non-uniform" work-groups are required for OpenCL 2.x devices, and support for non-uniform work-groups is optional for OpenCL 3.0 devices and can be queried using `CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT`.
 If non-uniform work-groups are supported, they will need to be enabled by compiling with the `-cl-std=CL2.0` or `-cl-std=CL3.0` compile, link, or build options.
 
 Additional notes:
@@ -22,11 +24,11 @@ Additional notes:
 
 ## Key APIs and Concepts
 
-This sample demonstrates how to specify groupings of work-items when enqueueing an OpenCL kernel for execution, by passing a non-NULL local work size to `clEnqueueNDRangeKernel`.
+This sample demonstrates how to specify groupings of work-items when enqueueing an OpenCL kernel for execution by passing a non-`NULL` local work size to `clEnqueueNDRangeKernel`.
 
 This sample also supports compiling and linking the program object separately using `clCompileProgram` and `clLinkProgram` rather than performing both steps using `clBuildProgram`.
 
-```c
+```
 clEnqueueNDRangeKernel with a non-NULL local work size
 clCompileProgram
 clLinkProgram
@@ -44,7 +46,7 @@ Can you find a local work size that performs better than the `NULL` local work s
 If not, what happens if you pass a local work size that does not evenly divide the global work size?
 If so, can you pass the right build options to enable non-uniform work-group support?
 3. Do you see any difference compiling and linking the program separately vs. building it in one step?
-4. Can load and compile a program from a different file and link with it?
+4. Can you load and compile a program from a different file and link with it?
 
 ## Command Line Options
 

--- a/samples/06_ndrangekernelfromfile/main.cpp
+++ b/samples/06_ndrangekernelfromfile/main.cpp
@@ -1,0 +1,176 @@
+/*
+// Copyright (c) 2019-2021 Ben Ashbaugh
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+*/
+
+#include <popl/popl.hpp>
+
+#include <CL/opencl.hpp>
+
+#include <fstream>
+#include <string>
+
+static std::string readStringFromFile(
+    const std::string& filename )
+{
+    std::ifstream is(filename, std::ios::binary);
+    if (!is.good()) {
+        printf("Couldn't open file '%s'!\n", filename.c_str());
+        return "";
+    }
+
+    size_t filesize = 0;
+    is.seekg(0, std::ios::end);
+    filesize = (size_t)is.tellg();
+    is.seekg(0, std::ios::beg);
+
+    std::string source{
+        std::istreambuf_iterator<char>(is),
+        std::istreambuf_iterator<char>() };
+
+    return source;
+}
+
+int main(
+    int argc,
+    char** argv )
+{
+    int platformIndex = 0;
+    int deviceIndex = 0;
+
+    std::string fileName("ndrange_sample_kernel.cl");
+    std::string kernelName("Test");
+    std::string buildOptions;
+    std::string compileOptions;
+    std::string linkOptions;
+    bool compile = false;
+    size_t gwx = 512;
+    size_t lwx = 32;
+
+    {
+        bool advanced = false;
+
+        popl::OptionParser op("Supported Options");
+        op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
+        op.add<popl::Value<int>>("d", "device", "Device Index", deviceIndex, &deviceIndex);
+        op.add<popl::Value<std::string>>("", "file", "Kernel File Name", fileName, &fileName);
+        op.add<popl::Value<std::string>>("", "name", "Kernel Name", kernelName, &kernelName);
+        op.add<popl::Value<std::string>>("", "options", "Program Build Options", buildOptions, &buildOptions);
+        op.add<popl::Value<size_t>>("", "gwx", "Global Work Size", gwx, &gwx);
+        op.add<popl::Value<size_t>>("", "lwx", "Local Work Size (0 -> NULL)", lwx, &lwx);
+        op.add<popl::Switch>("a", "advanced", "Show advanced options", &advanced);
+        op.add<popl::Switch, popl::Attribute::advanced>("c", "compilelink", "Use clCompileProgram and clLinkProgram", &compile);
+        op.add<popl::Value<std::string>, popl::Attribute::advanced>("", "compileoptions", "Program Compile Options", compileOptions, &compileOptions);
+        op.add<popl::Value<std::string>, popl::Attribute::advanced>("", "linkoptions", "Program Link Options", linkOptions, &linkOptions);
+        bool printUsage = false;
+        try {
+            op.parse(argc, argv);
+        } catch (std::exception& e) {
+            fprintf(stderr, "Error: %s\n\n", e.what());
+            printUsage = true;
+        }
+
+        if (printUsage || !op.unknown_options().empty() || !op.non_option_args().empty()) {
+            fprintf(stderr,
+                "Usage: ndrangekernelfromfile [options]\n"
+                "%s", op.help(advanced ? popl::Attribute::advanced : popl::Attribute::optional).c_str());
+            return -1;
+        }
+    }
+
+    std::vector<cl::Platform> platforms;
+    cl::Platform::get(&platforms);
+
+    printf("Running on platform: %s\n",
+        platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
+
+    std::vector<cl::Device> devices;
+    platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+
+    printf("Running on device: %s\n",
+        devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
+
+    cl::Context context{devices[deviceIndex]};
+    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+
+    printf("Reading program source from file: %s\n", fileName.c_str() );
+    std::string kernelString = readStringFromFile(fileName.c_str());
+
+    cl::Program program;
+    if (compile) {
+        printf("Compiling program with compile options: %s\n",
+            compileOptions.empty() ? "(none)" : compileOptions.c_str() );
+        cl::Program object{ context, kernelString };
+        object.compile(compileOptions.c_str());
+        for( auto& device : program.getInfo<CL_PROGRAM_DEVICES>() )
+        {
+            printf("Program compile log for device %s:\n",
+                device.getInfo<CL_DEVICE_NAME>().c_str() );
+            printf("%s\n",
+                object.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device).c_str() );
+        }
+
+        printf("Linking program with link options: %s\n",
+            linkOptions.empty() ? "(none)" : linkOptions.c_str() );
+        program = cl::linkProgram({object}, linkOptions.c_str());
+        for( auto& device : program.getInfo<CL_PROGRAM_DEVICES>() )
+        {
+            printf("Program link log for device %s:\n",
+                device.getInfo<CL_DEVICE_NAME>().c_str() );
+            printf("%s\n",
+                program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device).c_str() );
+        }
+    } else {
+        printf("Building program with build options: %s\n",
+            buildOptions.empty() ? "(none)" : buildOptions.c_str() );
+        program = cl::Program{ context, kernelString };
+        program.build(buildOptions.c_str());
+        for( auto& device : program.getInfo<CL_PROGRAM_DEVICES>() )
+        {
+            printf("Program build log for device %s:\n",
+                device.getInfo<CL_DEVICE_NAME>().c_str() );
+            printf("%s\n",
+                program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device).c_str() );
+        }
+    }
+    printf("Creating kernel: %s\n", kernelName.c_str() );
+    cl::Kernel kernel = cl::Kernel{ program, kernelName.c_str() };
+
+    cl::Buffer deviceMemDst = cl::Buffer{
+        context,
+        CL_MEM_ALLOC_HOST_PTR,
+        gwx * sizeof( cl_uint ) };
+
+    // execution
+    kernel.setArg(0, deviceMemDst);
+    commandQueue.enqueueNDRangeKernel(
+        kernel,
+        cl::NullRange,
+        cl::NDRange{gwx},
+        (lwx == 0) ? cl::NullRange : cl::NDRange{lwx});
+
+    // No results to check for this sample, but do verify that execution
+    // has completed.
+    commandQueue.finish();
+
+    printf("Done.\n");
+
+    return 0;
+}

--- a/samples/06_ndrangekernelfromfile/ndrange_sample_kernel.cl
+++ b/samples/06_ndrangekernelfromfile/ndrange_sample_kernel.cl
@@ -1,0 +1,5 @@
+kernel void Test( global uint* dst )
+{
+    uint index = get_global_id(0);
+    dst[index] = index;
+}

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -80,5 +80,6 @@ add_subdirectory( 03_mandelbrot )
 add_subdirectory( 04_julia )
 add_subdirectory( 05_kernelfromfile )
 add_subdirectory( 05_spirvkernelfromfile )
+add_subdirectory( 06_ndrangekernelfromfile )
 
 add_subdirectory( 10_queueexperiments )


### PR DESCRIPTION
Adds a variant of the "kernel from file" sample that uses a non-NULL local work size.

As an "advanced option", this sample also supports separate compilation and linking using `clCompileProgram` and `clLinkProgram` instead of performing both operations in one step using `clBuildProgram`.