### PR TITLE
use the local work size if provided

### DIFF
--- a/samples/python/04_julia/julia.py
+++ b/samples/python/04_julia/julia.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
 
     start = time.perf_counter()
     for i in range(iterations):
-        kernel(commandQueue, [gwx, gwy], None, 
+        kernel(commandQueue, [gwx, gwy], lws,
                deviceMemDst, np.float32(cr), np.float32(ci))
 
     # Ensure all processing is complete before stopping the timer.


### PR DESCRIPTION
Fixed bug that was causing the local work size to be ignored in the Julia set python sample if provided.