### PR TITLE
integrate the OpenCL Extension Loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --parallel --config $BUILD_TYPE
 
     #- name: Test
     #  working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Get Ubuntu OpenGL Dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install libglfw3-dev
+        sudo apt-get update
+        sudo apt-get install -y libglfw3-dev
 
     - name: Get OpenCL Headers
       uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        ext: [YES, NO]
 
     runs-on: ${{matrix.os}}
 
@@ -53,6 +54,13 @@ jobs:
       with:
         repository: KhronosGroup/OpenCL-ICD-Loader
         path: external/opencl-icd-loader
+
+    - name: Get OpenCL Extension Loader
+      if: matrix.ext == 'YES'
+      uses: actions/checkout@master
+      with:
+        repository: bashbaug/opencl-extension-loader
+        path: external/opencl-extension-loader
 
     - name: Create Build Directory
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,10 @@ add_subdirectory(external/opencl-icd-loader)
 set_target_properties(OpenCL PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set(OpenCL_LIBRARIES OpenCL)
 
-if(IS_DIRECTORY external/opencl-extension-loader)
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/external/opencl-extension-loader)
     add_subdirectory(external/opencl-extension-loader)
+else()
+    message(STATUS "OpenCL Extension Loader is not found.")
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ add_subdirectory(external/opencl-icd-loader)
 set_target_properties(OpenCL PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set(OpenCL_LIBRARIES OpenCL)
 
+if(IS_DIRECTORY external/opencl-extension-loader)
+    add_subdirectory(external/opencl-extension-loader)
+endif()
+
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     enable_testing()
 endif()

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ OpenCL ICD Loader:
 
     git clone https://github.com/KhronosGroup/opencl-icd-loader external/opencl-icd-loader
 
+Many samples that use extensions additionally require the OpenCL Extension Loader:
+
+    git clone https://github.com/bashbaug/opencl-extension-loader external/opencl-extension-loader
+
 After satisfying the external dependencies create build files using CMake.  For example:
 
     mkdir build && cd build

--- a/samples/usm/00_usmqueries/CMakeLists.txt
+++ b/samples/usm/00_usmqueries/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 120
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/00_usmqueries/main.cpp
+++ b/samples/usm/00_usmqueries/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 void PrintUSMCaps(
     const char* label,
@@ -69,7 +68,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/01_usmmeminfo/CMakeLists.txt
+++ b/samples/usm/01_usmmeminfo/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 120
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/01_usmmeminfo/main.cpp
+++ b/samples/usm/01_usmmeminfo/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 // Each of these functions should eventually move into opencl.hpp:
 
@@ -129,7 +128,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/100_dmemhelloworld/CMakeLists.txt
+++ b/samples/usm/100_dmemhelloworld/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 120
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/100_dmemhelloworld/main.cpp
+++ b/samples/usm/100_dmemhelloworld/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 const size_t    gwx = 1024*1024;
 
@@ -67,7 +66,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/101_dmemlinkedlist/CMakeLists.txt
+++ b/samples/usm/101_dmemlinkedlist/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 200
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/101_dmemlinkedlist/main.cpp
+++ b/samples/usm/101_dmemlinkedlist/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 cl::CommandQueue commandQueue;
 cl::Kernel kernel;
@@ -231,7 +230,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/200_hmemhelloworld/CMakeLists.txt
+++ b/samples/usm/200_hmemhelloworld/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 120
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/200_hmemhelloworld/main.cpp
+++ b/samples/usm/200_hmemhelloworld/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 const size_t    gwx = 1024*1024;
 
@@ -67,7 +66,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/201_hmemlinkedlist/CMakeLists.txt
+++ b/samples/usm/201_hmemlinkedlist/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 200
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/201_hmemlinkedlist/main.cpp
+++ b/samples/usm/201_hmemlinkedlist/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 cl::CommandQueue commandQueue;
 cl::Kernel kernel;
@@ -211,7 +210,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/300_smemhelloworld/CMakeLists.txt
+++ b/samples/usm/300_smemhelloworld/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 120
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/300_smemhelloworld/main.cpp
+++ b/samples/usm/300_smemhelloworld/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 const size_t    gwx = 1024*1024;
 
@@ -67,7 +66,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/301_smemlinkedlist/CMakeLists.txt
+++ b/samples/usm/301_smemlinkedlist/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 200
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/301_smemlinkedlist/main.cpp
+++ b/samples/usm/301_smemlinkedlist/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 cl::CommandQueue commandQueue;
 cl::Kernel kernel;
@@ -213,7 +212,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/310_usmmigratemem/CMakeLists.txt
+++ b/samples/usm/310_usmmigratemem/CMakeLists.txt
@@ -25,5 +25,4 @@ add_opencl_sample(
     VERSION 120
     CATEGORY usm
     SOURCES main.cpp
-    INCLUDES ${LIBUSM_INCLUDE_DIR}
-    LIBS usm)
+    LIBS OpenCLExt)

--- a/samples/usm/310_usmmigratemem/main.cpp
+++ b/samples/usm/310_usmmigratemem/main.cpp
@@ -23,7 +23,6 @@
 #include <popl/popl.hpp>
 
 #include <CL/opencl.hpp>
-#include "libusm.h"
 
 const size_t    gwx = 1024*1024;
 
@@ -67,7 +66,6 @@ int main(
 
     printf("Running on platform: %s\n",
         platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
-    libusm::initialize(platforms[platformIndex]());
 
     std::vector<cl::Device> devices;
     platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);

--- a/samples/usm/CMakeLists.txt
+++ b/samples/usm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Ben Ashbaugh
+# Copyright (c) 2021 Ben Ashbaugh
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,20 +18,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Require OpenCL 2.0, for clSetKernelExecInfo:
-set(SAMPLES_CL_VERSION 200)
+set(BUILD_USM_SAMPLES TRUE)
+if(NOT TARGET OpenCLExt)
+    message(STATUS "Skipping USM Samples - OpenCL Extension Loader is not found.")
+    set(BUILD_USM_SAMPLES FALSE)
+endif()
 
-add_subdirectory( libusm )
+if(BUILD_USM_SAMPLES)
+    add_subdirectory( 00_usmqueries )
+    add_subdirectory( 01_usmmeminfo )
 
-add_subdirectory( 00_usmqueries )
-add_subdirectory( 01_usmmeminfo )
+    add_subdirectory( 100_dmemhelloworld )
+    add_subdirectory( 101_dmemlinkedlist )
 
-add_subdirectory( 100_dmemhelloworld )
-add_subdirectory( 101_dmemlinkedlist )
+    add_subdirectory( 200_hmemhelloworld )
+    add_subdirectory( 201_hmemlinkedlist )
 
-add_subdirectory( 200_hmemhelloworld )
-add_subdirectory( 201_hmemlinkedlist )
-
-add_subdirectory( 300_smemhelloworld )
-add_subdirectory( 301_smemlinkedlist )
-add_subdirectory( 310_usmmigratemem )
+    add_subdirectory( 300_smemhelloworld )
+    add_subdirectory( 301_smemlinkedlist )
+    add_subdirectory( 310_usmmigratemem )
+endif()

--- a/samples/usm/README.md
+++ b/samples/usm/README.md
@@ -13,6 +13,8 @@ Because the interfaces defined by the `cl_intel_unified_shared_memory` extension
 
 These samples are in sync with the USM extension draft revision H.
 
+These samples require the OpenCL Extension Loader to get the extension APIs for Unified Shared Memory.
+
 ## Unified Shared Memory Advantages
 
 Unified Shared Memory (USM) provides:


### PR DESCRIPTION
Switches most samples that use extensions - in particular the USM samples - to the OpenCL extension loader.

* Updated CMake files to conditionally build the USM samples only if the extension loader target is found.
* Updated READMEs to document the extension loader dependencies.
* Added CI targets to build with and without the extension loader.