### PR TITLE
add subdirectory for OpenCL-Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(OpenCL)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${OpenCL_INCLUDE_DIR})
 
+add_subdirectory(external/OpenCL-Headers)
 add_subdirectory(external/opencl-icd-loader)
 set_target_properties(OpenCL PROPERTIES FOLDER "OpenCL-ICD-Loader")
 set(OpenCL_LIBRARIES OpenCL)


### PR DESCRIPTION
After the recent OpenCL headers and OpenCL ICD loader cmake rework, we now need to add the OpenCL-Headers as a project.