### PR TITLE
update Vulkan sample with external memory and semaphore sharing

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1552,6 +1552,13 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_EXTERNAL_MEMORY_IMPOR
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_memory_handle_type_khr>)
 #endif // cl_khr_external_memory
 
+#if defined(cl_khr_external_semaphore)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_semaphore_handle_type_khr>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_semaphore_handle_type_khr>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SEMAPHORE_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_semaphore_handle_type_khr>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SEMAPHORE_EXPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_semaphore_handle_type_khr>)
+#endif // cl_khr_external_semaphore
+
 #ifdef CL_PLATFORM_ICD_SUFFIX_KHR
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_ICD_SUFFIX_KHR, string)
 #endif

--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1547,6 +1547,11 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_command_buffer_info_khr, CL_COMMAND_BUFFER_STATE
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_command_buffer_info_khr, CL_COMMAND_BUFFER_PROPERTIES_ARRAY_KHR, cl::vector<cl_command_buffer_properties_khr>)
 #endif // cl_khr_command_buffer
 
+#if defined(cl_khr_external_memory)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_memory_handle_type_khr>)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_EXTERNAL_MEMORY_IMPORT_HANDLE_TYPES_KHR, cl::vector<cl_external_memory_handle_type_khr>)
+#endif // cl_khr_external_memory
+
 #ifdef CL_PLATFORM_ICD_SUFFIX_KHR
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_platform_info, CL_PLATFORM_ICD_SUFFIX_KHR, string)
 #endif

--- a/samples/vulkan/00_juliavk/CMakeLists.txt
+++ b/samples/vulkan/00_juliavk/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Ben Ashbaugh
+# Copyright (c) 2021-2022 Ben Ashbaugh
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/samples/vulkan/00_juliavk/CMakeLists.txt
+++ b/samples/vulkan/00_juliavk/CMakeLists.txt
@@ -26,4 +26,4 @@ add_opencl_sample(
     SOURCES main.cpp
     KERNELS juliavk.vert.spv juliavk.frag.spv
     INCLUDES ${Vulkan_INCLUDE_DIR}
-    LIBS ${Vulkan_LIBRARY} glfw OpenCLExt)
+    LIBS ${Vulkan_LIBRARY} glfw)

--- a/samples/vulkan/00_juliavk/CMakeLists.txt
+++ b/samples/vulkan/00_juliavk/CMakeLists.txt
@@ -21,7 +21,7 @@
 add_opencl_sample(
     NUMBER 00
     TARGET juliavk
-    VERSION 120
+    VERSION 300 # clCreateImageWithProperties
     CATEGORY vulkan
     SOURCES main.cpp
     KERNELS juliavk.vert.spv juliavk.frag.spv

--- a/samples/vulkan/00_juliavk/CMakeLists.txt
+++ b/samples/vulkan/00_juliavk/CMakeLists.txt
@@ -26,4 +26,4 @@ add_opencl_sample(
     SOURCES main.cpp
     KERNELS juliavk.vert.spv juliavk.frag.spv
     INCLUDES ${Vulkan_INCLUDE_DIR}
-    LIBS ${Vulkan_LIBRARY} glfw)
+    LIBS ${Vulkan_LIBRARY} glfw OpenCLExt)

--- a/samples/vulkan/00_juliavk/README.md
+++ b/samples/vulkan/00_juliavk/README.md
@@ -49,6 +49,7 @@ Note: Many of these command line arguments are identical to the earlier Julia se
 | `--gwy <number>` | 512 | Specify the global work size to execute, in the Y direction.  This also determines the height of the generated image.
 | `--lwx <number>` | 0 | Specify the local work size in the X direction.  If either local works size dimension is zero a `NULL` local work size is used.
 | `--lwy <number>` | 0 | Specify the local work size in the Y direction.  If either local works size dimension is zero a `NULL` local work size is used.
+| `--immediate` | n/a | Prefer `VK_PRESENT_MODE_IMMEDIATE_KHR` (no vsync).  May result in faster framerates at the cost of visible tearing.
 
 ## Controls While Running
 

--- a/samples/vulkan/00_juliavk/README.md
+++ b/samples/vulkan/00_juliavk/README.md
@@ -62,6 +62,7 @@ Note: Many of these command line arguments are identical to the earlier Julia se
 | `-p <index>` | 0 | Specify the index of the OpenCL platform to execute the sample on.
 | `--hostcopy` | n/a | Do not use the `cl_khr_external_memory` extension and unconditionally copy on the host.
 | `--hostsync` | n/a | Do not use the `cl_khr_external_semaphore` extension and exclusively synchronize on the host.
+| `--nodevicelocal` | n/a | Do not use device local images (`VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`).  May be useful for debugging.
 | `--gwx <number>` | 512 | Specify the global work size to execute, in the X direction.  This also determines the width of the generated image.
 | `--gwy <number>` | 512 | Specify the global work size to execute, in the Y direction.  This also determines the height of the generated image.
 | `--lwx <number>` | 0 | Specify the local work size in the X direction.  If either local works size dimension is zero a `NULL` local work size is used.

--- a/samples/vulkan/00_juliavk/README.md
+++ b/samples/vulkan/00_juliavk/README.md
@@ -19,6 +19,9 @@ Sharing a semaphore object between Vulkan and OpenCL avoids synchronization on t
 For more information about these extensions, please see [this blog post](https://www.khronos.org/blog/khronos-releases-opencl-3.0-extensions-for-neural-network-inferencing-and-opencl-vulkan-interop).
 When the extensions are not supported the sample will still run, although perhaps with lower performance.
 
+Important note: The OpenCL extensions used in this sample are very new!
+If the sample does not run correctly please ensure you are using the latest OpenCL drivers for your device, or use the command line option to force copying on the host.
+
 ## Key APIs and Concepts
 
 This example shows how to share an Vulkan texture and semaphore with OpenCL.

--- a/samples/vulkan/00_juliavk/README.md
+++ b/samples/vulkan/00_juliavk/README.md
@@ -11,10 +11,27 @@ In order to share the Vulkan texture with OpenCL, the OpenCL device must support
 Additionally, the Vulkan device must support exporting the Vulkan texture as an OS-specific external memory handle, and the OpenCL device must support importing external memory handles of that type.
 Creating the OpenCL image directly from the Vulkan texture avoids a memory copy and can improve performance.
 
+For Windows, the external memory handle types that are currently supported are:
+
+* `CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR`
+
+For Linux, the external memory handle types that are currently supported are:
+
+* `CL_EXTERNAL_MEMORY_HANDLE_DMA_BUF_KHR`
+* `CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR`
+
 This sample can also share semaphores between Vulkan and OpenCL when supported.
 In order to share a Vulkan semaphore with OpenCL, the OpenCL device must support [cl_khr_external_semaphore](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_external_semaphore).
 Additionally, the Vulkan device must support exporting the Vulkan semaphore as an OS-specific external semaphore handle, and the OpenCL device must support importing external semaphore handles of that type.
 Sharing a semaphore object between Vulkan and OpenCL avoids synchronization on the host and can also improve performance.
+
+For Windows, the external semaphore handle types that are currently supported are:
+
+* `CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR`
+
+For Linux, the external semaphore handle types that are currently supported are:
+
+* `CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR`
 
 For more information about these extensions, please see [this blog post](https://www.khronos.org/blog/khronos-releases-opencl-3.0-extensions-for-neural-network-inferencing-and-opencl-vulkan-interop).
 When the extensions are not supported the sample will still run, although perhaps with lower performance.

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -246,7 +246,6 @@ private:
     cl::Kernel kernel;
 
     std::vector<cl::Image2D> mems;
-    std::vector<cl_semaphore_khr> waitSemaphores;
     std::vector<cl_semaphore_khr> signalSemaphores;
 
     clEnqueueAcquireExternalMemObjectsKHR_fn clEnqueueAcquireExternalMemObjectsKHR = NULL;

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -660,7 +660,7 @@ private:
             }
         }
         if (useExternalSemaphore) {
-            pvkGetSemaphoreFdKHR = (PFN_vkGetSemaphoreFdKHR)vkGetInstanceProcAddr(instance, "pvkGetMemoryFdKHR");
+            pvkGetSemaphoreFdKHR = (PFN_vkGetSemaphoreFdKHR)vkGetInstanceProcAddr(instance, "vkGetSemaphoreFdKHR");
             if (pvkGetSemaphoreFdKHR == NULL) {
                 throw std::runtime_error("couldn't get external function pointer for vkGetSemaphoreFdKHR");
             }
@@ -1864,6 +1864,7 @@ private:
 #ifdef _WIN32
             extensions.push_back(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
 #elif defined(__linux__)
+            extensions.push_back(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
 #endif
         }
         if (useExternalSemaphore) {
@@ -1871,6 +1872,7 @@ private:
 #ifdef _WIN32
             extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
 #elif defined(__linux__)
+            extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
 #endif
         }
 

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -238,7 +238,6 @@ private:
     int platformIndex = 0;
     int deviceIndex = 0;
 
-    bool force = false;
     bool useExternalMemory = true;
     bool useExternalSemaphore = true;
 
@@ -264,7 +263,6 @@ private:
         popl::OptionParser op("Supported Options");
         op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
         op.add<popl::Value<int>>("d", "device", "Device Index", deviceIndex, &deviceIndex);
-        op.add<popl::Switch>("", "force", "Bypass Extension Checks", &force);
         op.add<popl::Switch>("", "hostcopy", "Do not use cl_khr_external_memory", &hostCopy);
         op.add<popl::Switch>("", "hostsync", "Do not use cl_khr_external_semaphore", &hostSync);
         op.add<popl::Value<size_t>>("", "gwx", "Global Work Size X AKA Image Width", gwx, &gwx);
@@ -338,9 +336,7 @@ private:
             }
         } else {
             printf("Device does not support cl_khr_external_memory.\n");
-            if (!force) {
-                useExternalMemory = false;
-            }
+            useExternalMemory = false;
         }
 
         if (checkDeviceForExtension(devices[deviceIndex], "cl_khr_external_semaphore")) {
@@ -362,9 +358,7 @@ private:
             }
         } else {
             printf("Device does not support cl_khr_external_semaphore.\n");
-            if (!force) {
-                useExternalSemaphore = false;
-            }
+            useExternalSemaphore = false;
         }
 
         if (useExternalMemory) {

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -98,7 +98,7 @@ kernel void Julia( write_only image2d_t dst, float cr, float ci )
 const int MAX_FRAMES_IN_FLIGHT = 2;
 
 const std::vector<const char*> validationLayers = {
-    "VK_LAYER_KHRONOS_validation",
+//    "VK_LAYER_KHRONOS_validation",
     "VK_LAYER_LUNARG_api_dump",
 };
 
@@ -225,7 +225,7 @@ private:
     std::vector<VkFence> imagesInFlight;
     size_t currentFrame = 0;
 
-#define CREATE_DUMMY_OBJECTS
+//#define CREATE_DUMMY_OBJECTS
 #ifdef CREATE_DUMMY_OBJECTS
     VkBuffer dummyBuffer;
     VkDeviceMemory dummyBufferMemory;
@@ -347,7 +347,7 @@ private:
             getWin32HandleInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;    // TODO: KMT handles?
             pvkGetMemoryWin32HandleKHR(device, &getWin32HandleInfo, &handle);
 
-#if 0
+#if 1
             // This works:
             const cl_mem_properties props[] = {
                 CL_DEVICE_HANDLE_LIST_KHR,
@@ -367,7 +367,7 @@ private:
                 (cl_mem_properties)handle,
                 0,
             };
-#elif 1
+#elif 0
             // This omits the device handle list entirely and does not work:
             const cl_mem_properties props[] = {
                 CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
@@ -402,28 +402,31 @@ private:
                 pvkGetMemoryWin32HandleKHR(device, &getWin32HandleInfo, &handle);
 
                 const cl_mem_properties props[] = {
+                    CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
+                    (cl_mem_properties)handle,
                     CL_DEVICE_HANDLE_LIST_KHR,
                     (cl_mem_properties)context.getInfo<CL_CONTEXT_DEVICES>().front()(),
                     0x2052, //CL_DEVICE_HANDLE_LIST_END_KHR,
-                    CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
-                    (cl_mem_properties)handle,
                     0,
                 };
 
                 cl_image_format format{};
                 format.image_channel_order = CL_RGBA;
-                format.image_channel_data_type = CL_UNORM_INT8;
+                //format.image_channel_data_type = CL_UNORM_INT8;
+                format.image_channel_data_type = CL_UNSIGNED_INT8;
 
                 cl_image_desc desc{};
                 desc.image_type = CL_MEM_OBJECT_IMAGE2D;
                 desc.image_width = gwx;
                 desc.image_height = gwy;
+                desc.num_mip_levels = 1;    // Workaround
 
                 mems[i] = cl::Image2D{
                     clCreateImageWithProperties(
                         context(),
                         props,
-                        CL_MEM_WRITE_ONLY,
+                        //CL_MEM_WRITE_ONLY,
+                        CL_MEM_READ_WRITE,
                         &format,
                         &desc,
                         NULL,
@@ -1013,10 +1016,13 @@ private:
             createImage(
                 texWidth,
                 texHeight,
-                VK_FORMAT_R8G8B8A8_UNORM,
+                VK_FORMAT_R8G8B8A8_UINT,
+                //VK_FORMAT_R8G8B8A8_UNORM,
                 VK_IMAGE_TILING_OPTIMAL,
-                VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                //VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                0,
+                //VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                 textureImages[i],
                 textureImageMemories[i]);
         }

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -210,6 +210,7 @@ private:
     VkBuffer stagingBuffer;
     VkDeviceMemory stagingBufferMemory;
 
+    bool deviceLocalImages = true;
     std::vector<VkImage> textureImages;
     std::vector<VkDeviceMemory> textureImageMemories;
     std::vector<VkImageView> textureImageViews;
@@ -261,6 +262,7 @@ private:
     void commandLine(int argc, char** argv) {
         bool hostCopy = false;
         bool hostSync = false;
+        bool noDeviceLocal = false;
         bool immediate = false;
 
         popl::OptionParser op("Supported Options");
@@ -268,6 +270,7 @@ private:
         op.add<popl::Value<int>>("d", "device", "Device Index", deviceIndex, &deviceIndex);
         op.add<popl::Switch>("", "hostcopy", "Do not use cl_khr_external_memory", &hostCopy);
         op.add<popl::Switch>("", "hostsync", "Do not use cl_khr_external_semaphore", &hostSync);
+        op.add<popl::Switch>("", "nodevicelocal", "Do not use device local images", &noDeviceLocal);
         op.add<popl::Value<size_t>>("", "gwx", "Global Work Size X AKA Image Width", gwx, &gwx);
         op.add<popl::Value<size_t>>("", "gwy", "Global Work Size Y AKA Image Height", gwy, &gwy);
         op.add<popl::Value<size_t>>("", "lwx", "Local Work Size X", lwx, &lwx);
@@ -289,6 +292,7 @@ private:
             throw std::runtime_error("exiting.");
         }
 
+        deviceLocalImages = !noDeviceLocal;
         useExternalMemory = !hostCopy;
         useExternalSemaphore = !hostSync;
         vsync = !immediate;
@@ -1034,7 +1038,7 @@ private:
                 VK_FORMAT_R8G8B8A8_UNORM,
                 VK_IMAGE_TILING_OPTIMAL,
                 VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                deviceLocalImages ? VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT : 0,
                 textureImages[i],
                 textureImageMemories[i]);
             if (useExternalMemory) {

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -98,7 +98,7 @@ kernel void Julia( write_only image2d_t dst, float cr, float ci )
 const int MAX_FRAMES_IN_FLIGHT = 2;
 
 const std::vector<const char*> validationLayers = {
-//    "VK_LAYER_KHRONOS_validation",
+    "VK_LAYER_KHRONOS_validation",
     "VK_LAYER_LUNARG_api_dump",
 };
 
@@ -225,7 +225,7 @@ private:
     std::vector<VkFence> imagesInFlight;
     size_t currentFrame = 0;
 
-//#define CREATE_DUMMY_OBJECTS
+#define CREATE_DUMMY_OBJECTS
 #ifdef CREATE_DUMMY_OBJECTS
     VkBuffer dummyBuffer;
     VkDeviceMemory dummyBufferMemory;
@@ -402,18 +402,17 @@ private:
                 pvkGetMemoryWin32HandleKHR(device, &getWin32HandleInfo, &handle);
 
                 const cl_mem_properties props[] = {
-                    CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
-                    (cl_mem_properties)handle,
                     CL_DEVICE_HANDLE_LIST_KHR,
                     (cl_mem_properties)context.getInfo<CL_CONTEXT_DEVICES>().front()(),
                     0x2052, //CL_DEVICE_HANDLE_LIST_END_KHR,
+                    CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_WIN32_KHR,
+                    (cl_mem_properties)handle,
                     0,
                 };
 
                 cl_image_format format{};
                 format.image_channel_order = CL_RGBA;
-                //format.image_channel_data_type = CL_UNORM_INT8;
-                format.image_channel_data_type = CL_UNSIGNED_INT8;
+                format.image_channel_data_type = CL_UNORM_INT8;
 
                 cl_image_desc desc{};
                 desc.image_type = CL_MEM_OBJECT_IMAGE2D;
@@ -425,8 +424,7 @@ private:
                     clCreateImageWithProperties(
                         context(),
                         props,
-                        //CL_MEM_WRITE_ONLY,
-                        CL_MEM_READ_WRITE,
+                        CL_MEM_WRITE_ONLY,
                         &format,
                         &desc,
                         NULL,
@@ -1016,13 +1014,10 @@ private:
             createImage(
                 texWidth,
                 texHeight,
-                VK_FORMAT_R8G8B8A8_UINT,
-                //VK_FORMAT_R8G8B8A8_UNORM,
+                VK_FORMAT_R8G8B8A8_UNORM,
                 VK_IMAGE_TILING_OPTIMAL,
-                VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-                //VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-                0,
-                //VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                 textureImages[i],
                 textureImageMemories[i]);
         }

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -279,7 +279,7 @@ private:
 
         if (printUsage || !op.unknown_options().empty() || !op.non_option_args().empty()) {
             fprintf(stderr,
-                "Usage: juliagl [options]\n"
+                "Usage: juliavk [options]\n"
                 "%s", op.help().c_str());
             throw std::runtime_error("exiting.");
         }

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -177,6 +177,7 @@ private:
     float cr = -0.123f;
     float ci =  0.745f;
 
+    bool vsync = true;
     size_t startFrame = 0;
     size_t frame = 0;
     std::chrono::system_clock::time_point start =
@@ -258,6 +259,7 @@ private:
     void commandLine(int argc, char** argv) {
         bool hostCopy = false;
         bool hostSync = false;
+        bool immediate = false;
 
         popl::OptionParser op("Supported Options");
         op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
@@ -268,6 +270,7 @@ private:
         op.add<popl::Value<size_t>>("", "gwy", "Global Work Size Y AKA Image Height", gwy, &gwy);
         op.add<popl::Value<size_t>>("", "lwx", "Local Work Size X", lwx, &lwx);
         op.add<popl::Value<size_t>>("", "lwy", "Local Work Size Y", lwy, &lwy);
+        op.add<popl::Switch>("", "immediate", "Prefer VK_PRESENT_MODE_IMMEDIATE_KHR (no vsync)", &immediate);
 
         bool printUsage = false;
         try {
@@ -286,6 +289,7 @@ private:
 
         useExternalMemory = !hostCopy;
         useExternalSemaphore = !hostSync;
+        vsync = !immediate;
     }
 
     void initWindow() {
@@ -1694,8 +1698,14 @@ private:
 
     VkPresentModeKHR chooseSwapPresentMode(const std::vector<VkPresentModeKHR>& availablePresentModes) {
         for (const auto& availablePresentMode : availablePresentModes) {
-            if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
-                return availablePresentMode;
+            if (vsync) {
+                if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
+                    return availablePresentMode;
+                }
+            } else {
+                if (availablePresentMode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
+                    return availablePresentMode;
+                }
             }
         }
 

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -378,7 +378,7 @@ private:
                 VkMemoryGetFdInfoKHR getFdInfo{};
                 getFdInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
                 getFdInfo.memory = textureImageMemories[i];
-                getFdInfo.handleType = 
+                getFdInfo.handleType =
                     externalMemType == CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR ?
                     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT :
                     VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
@@ -1097,7 +1097,7 @@ private:
 #ifdef _WIN32
         externalMemCreateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 #elif defined(__linux__)
-        externalMemCreateInfo.handleTypes = 
+        externalMemCreateInfo.handleTypes =
             externalMemType == CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR ?
             VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT :
             VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -1208,10 +1208,10 @@ private:
         getFdInfo.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
         vkGetSemaphoreFdKHR(device, &getFdInfo, &fd);
 
-        const cl_mem_properties props[] = {
+        const cl_semaphore_properties_khr props[] = {
             CL_SEMAPHORE_TYPE_KHR,
             CL_SEMAPHORE_TYPE_BINARY_KHR,
-            CL_EXTERNAL_MEMORY_HANDLE_OPAQUE_FD_KHR,
+            CL_SEMAPHORE_HANDLE_OPAQUE_FD_KHR,
             (cl_semaphore_properties_khr)fd,
             0,
         };

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -225,7 +225,7 @@ private:
     std::vector<VkFence> imagesInFlight;
     size_t currentFrame = 0;
 
-//#define CREATE_DUMMY_OBJECTS
+#define CREATE_DUMMY_OBJECTS
 #ifdef CREATE_DUMMY_OBJECTS
     VkBuffer dummyBuffer;
     VkDeviceMemory dummyBufferMemory;
@@ -339,7 +339,7 @@ private:
 
     void initOpenCLMems() {
 #ifdef CREATE_DUMMY_OBJECTS
-        {
+        if (useExternalMemory) {
             HANDLE handle = NULL;
             VkMemoryGetWin32HandleInfoKHR getWin32HandleInfo{};
             getWin32HandleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
@@ -1130,7 +1130,7 @@ private:
         vkBindImageMemory(device, image, imageMemory, 0);
 
 #ifdef CREATE_DUMMY_OBJECTS
-        {
+        if (useExternalMemory) {
 #ifdef _WIN32
             VkExternalMemoryBufferCreateInfo externalMemCreateInfo{};
             externalMemCreateInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO;

--- a/samples/vulkan/CMakeLists.txt
+++ b/samples/vulkan/CMakeLists.txt
@@ -30,11 +30,6 @@ if(NOT glfw3_FOUND)
     message(STATUS "Skipping Vulkan Samples - GLFW is not found.")
     set(BUILD_VULKAN_SAMPLES FALSE)
 endif()
-if(NOT TARGET OpenCLExt)
-    message(STATUS "Skipping Vulkan Samples - OpenCL Extension Loader is not found.")
-    set(BUILD_VULKAN_SAMPLES FALSE)
-endif()
-
 
 if(BUILD_VULKAN_SAMPLES)
     add_subdirectory( 00_juliavk )

--- a/samples/vulkan/CMakeLists.txt
+++ b/samples/vulkan/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Ben Ashbaugh
+# Copyright (c) 2020-2022 Ben Ashbaugh
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,11 @@ if(NOT glfw3_FOUND)
     message(STATUS "Skipping Vulkan Samples - GLFW is not found.")
     set(BUILD_VULKAN_SAMPLES FALSE)
 endif()
+if(NOT TARGET OpenCLExt)
+    message(STATUS "Skipping Vulkan Samples - OpenCL Extension Loader is not found.")
+    set(BUILD_VULKAN_SAMPLES FALSE)
+endif()
+
 
 if(BUILD_VULKAN_SAMPLES)
     add_subdirectory( 00_juliavk )


### PR DESCRIPTION
Updates the Vulkan sample to use external memory sharing and external semaphore sharing, when supported.

On one of my systems, this improves the performance from:

* host copy, host sync: 1100 fps
* external memory sharing, host sync: 3400 fps
* external memory, external semaphore sharing: 4400 fps

Note: be sure to use the latest drivers!

Note: still need to test Linux (but it should work in theory).