### PR TITLE
print the platform index when enumerating OpenCL platforms

### DIFF
--- a/samples/00_enumopencl/main.cpp
+++ b/samples/00_enumopencl/main.cpp
@@ -194,7 +194,7 @@ static void PrintDeviceType(
 
 static cl_int PrintDeviceInfoSummary(
     cl_device_id* devices,
-    size_t numDevices )
+    cl_uint numDevices )
 {
     cl_int  errorCode = CL_SUCCESS;
 
@@ -204,8 +204,7 @@ static cl_int PrintDeviceInfoSummary(
     char*           deviceVersion = NULL;
     char*           driverVersion = NULL;
 
-    size_t  i = 0;
-    for( i = 0; i < numDevices; i++ )
+    for( cl_uint i = 0; i < numDevices; i++ )
     {
         errorCode |= clGetDeviceInfo(
             devices[i],
@@ -232,7 +231,7 @@ static cl_int PrintDeviceInfoSummary(
 
         if( errorCode == CL_SUCCESS )
         {
-            printf("Device[%d]:\n", (int)i );
+            printf("Device[%u]:\n", i );
 
             PrintDeviceType("\tType:           ", deviceType);
 
@@ -243,7 +242,7 @@ static cl_int PrintDeviceInfoSummary(
         }
         else
         {
-            fprintf(stderr, "Error getting device info for device %d.\n", (int)i );
+            fprintf(stderr, "Error getting device info for device %u.\n", i );
         }
 
         delete [] deviceName;
@@ -291,17 +290,17 @@ int main(
     platforms.resize( numPlatforms );
     clGetPlatformIDs( numPlatforms, platforms.data(), NULL );
 
-    for( auto& platform : platforms )
+    for( cl_uint i = 0; i < numPlatforms; i++ )
     {
-        printf( "Platform:\n" );
-        PrintPlatformInfoSummary( platform );
+        printf( "Platform[%u]:\n", i );
+        PrintPlatformInfoSummary( platforms[i] );
 
         cl_uint numDevices = 0;
-        clGetDeviceIDs( platform, CL_DEVICE_TYPE_ALL, 0, NULL, &numDevices );
+        clGetDeviceIDs( platforms[i], CL_DEVICE_TYPE_ALL, 0, NULL, &numDevices );
 
         std::vector<cl_device_id> devices;
         devices.resize( numDevices );
-        clGetDeviceIDs( platform, CL_DEVICE_TYPE_ALL, numDevices, devices.data(), NULL );
+        clGetDeviceIDs( platforms[i], CL_DEVICE_TYPE_ALL, numDevices, devices.data(), NULL );
 
         PrintDeviceInfoSummary( devices.data(), numDevices );
         printf( "\n" );

--- a/samples/00_enumopenclpp/main.cpp
+++ b/samples/00_enumopenclpp/main.cpp
@@ -52,10 +52,9 @@ static void PrintDeviceType(
 static cl_int PrintDeviceInfoSummary(
     const std::vector<cl::Device> devices )
 {
-    size_t  i = 0;
-    for( i = 0; i < devices.size(); i++ )
+    for( size_t i = 0; i < devices.size(); i++ )
     {
-        printf("Device[%d]:\n", (int)i );
+        printf("Device[%zu]:\n", i );
 
         cl_device_type  deviceType = devices[i].getInfo<CL_DEVICE_TYPE>();
         PrintDeviceType("\tType:           ", deviceType);
@@ -95,13 +94,13 @@ int main(
     std::vector<cl::Platform> platforms;
     cl::Platform::get(&platforms);
 
-    for( auto& platform : platforms )
+    for( size_t i = 0; i < platforms.size(); i++ )
     {
-        printf( "Platform:\n" );
-        PrintPlatformInfoSummary( platform );
+        printf( "Platform[%zu]:\n", i );
+        PrintPlatformInfoSummary( platforms[i] );
 
         std::vector<cl::Device> devices;
-        platform.getDevices(CL_DEVICE_TYPE_ALL, &devices);
+        platforms[i].getDevices(CL_DEVICE_TYPE_ALL, &devices);
 
         PrintDeviceInfoSummary( devices );
         printf( "\n" );

--- a/samples/python/00_enumopencl/enumopencl.py
+++ b/samples/python/00_enumopencl/enumopencl.py
@@ -22,13 +22,13 @@
 
 import pyopencl as cl
 
-for platform in cl.get_platforms():
-    print("Platform:")
+for p, platform in enumerate(cl.get_platforms()):
+    print("Platform[{}]:".format(p))
     print("        Name:           " + platform.get_info(cl.platform_info.NAME))
     print("        Vendor:         " + platform.get_info(cl.platform_info.VENDOR))
     print("        Driver Version: " + platform.get_info(cl.platform_info.VERSION))
-    for i, device in enumerate(platform.get_devices()):
-        print("Device[{}]:".format(i))
+    for d, device in enumerate(platform.get_devices()):
+        print("Device[{}]:".format(d))
         print("        Type:           " + cl.device_type.to_string(device.get_info(cl.device_info.TYPE)))
         print("        Name:           " + device.get_info(cl.device_info.NAME))
         print("        Vendor:         " + device.get_info(cl.device_info.VENDOR))


### PR DESCRIPTION
Prints the platform index when enumerating OpenCL platforms.

This can make it easier to determine which platform index to specify, especially on systems with many OpenCL platforms.