### PR TITLE
improves handling of command buffer emulation events

### DIFF
--- a/layers/10_cmdbufemu/README.md
+++ b/layers/10_cmdbufemu/README.md
@@ -30,6 +30,4 @@ clInitLayer
 
 This section describes some of the limitations of the emulated `cl_khr_command_buffer` functionality:
 
-* The event associated with `clEnqueueCommandBufferKHR` will not have the proper event command type `CL_COMMAND_COMMAND_BUFFER_KHR`.
-* Event profiling for `clEnqueueCommandBufferKHR` will not be correct for the `QUEUED`, `SUBMITTED`, and `START` times.
 * Many error conditions are not properly checked for and returned.

--- a/layers/10_cmdbufemu/README.md
+++ b/layers/10_cmdbufemu/README.md
@@ -31,3 +31,4 @@ clInitLayer
 This section describes some of the limitations of the emulated `cl_khr_command_buffer` functionality:
 
 * Many error conditions are not properly checked for and returned.
+* Many functions are not thread safe.

--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -18,6 +18,12 @@
 
 #include "emulate.h"
 
+SLayerContext& getLayerContext(void)
+{
+    static SLayerContext c;
+    return c;
+}
+
 #if defined(cl_khr_command_buffer_mutable_dispatch)
 
 // Supported mutable dispatch capabilities.
@@ -1465,7 +1471,7 @@ cl_int CL_API_CALL clEnqueueCommandBufferKHR_EMU(
     {
         if( errorCode == CL_SUCCESS )
         {
-            g_pLayerContext->EventMap[event[0]] = startEvent;
+            getLayerContext().EventMap[event[0]] = startEvent;
         }
         else
         {
@@ -2224,8 +2230,9 @@ bool clGetEventInfo_override(
     switch(param_name) {
     case CL_EVENT_COMMAND_TYPE:
         {
-            auto it = g_pLayerContext->EventMap.find(event);
-            if (it != g_pLayerContext->EventMap.end()) {
+            auto& context = getLayerContext();
+            auto it = context.EventMap.find(event);
+            if (it != context.EventMap.end()) {
                 cl_command_type type = CL_COMMAND_COMMAND_BUFFER_KHR;
                 auto ptr = (cl_command_type*)param_value;
                 cl_int errorCode = writeParamToMemory(
@@ -2260,8 +2267,9 @@ bool clGetEventProfilingInfo_override(
     case CL_PROFILING_COMMAND_SUBMIT:
     case CL_PROFILING_COMMAND_START:
         {
-            auto it = g_pLayerContext->EventMap.find(event);
-            if (it != g_pLayerContext->EventMap.end()) {
+            auto& context = getLayerContext();
+            auto it = context.EventMap.find(event);
+            if (it != context.EventMap.end()) {
                 cl_int errorCode = g_pNextDispatch->clGetEventProfilingInfo(
                     it->second,
                     param_name,

--- a/layers/10_cmdbufemu/emulate.h
+++ b/layers/10_cmdbufemu/emulate.h
@@ -15,8 +15,9 @@ struct SLayerContext
     CEventMap EventMap;
 };
 
+SLayerContext& getLayerContext(void);
+
 extern const struct _cl_icd_dispatch* g_pNextDispatch;
-extern struct SLayerContext* g_pLayerContext;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Emulated Functions

--- a/layers/10_cmdbufemu/emulate.h
+++ b/layers/10_cmdbufemu/emulate.h
@@ -7,6 +7,17 @@
 #include <CL/cl.h>
 #include <CL/cl_ext.h>
 
+#include <map>
+
+struct SLayerContext
+{
+    typedef std::map<cl_event, cl_event> CEventMap;
+    CEventMap EventMap;
+};
+
+extern const struct _cl_icd_dispatch* g_pNextDispatch;
+extern struct SLayerContext* g_pLayerContext;
+
 ///////////////////////////////////////////////////////////////////////////////
 // Emulated Functions
 
@@ -177,6 +188,22 @@ cl_int CL_API_CALL clGetMutableCommandInfoKHR_EMU(
 bool clGetDeviceInfo_override(
     cl_device_id device,
     cl_device_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret,
+    cl_int* errcode_ret);
+
+bool clGetEventInfo_override(
+    cl_event event,
+    cl_event_info param_name,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret,
+    cl_int* errcode_ret);
+
+bool clGetEventProfilingInfo_override(
+    cl_event event,
+    cl_profiling_info param_name,
     size_t param_value_size,
     void* param_value,
     size_t* param_value_size_ret,

--- a/layers/10_cmdbufemu/main.cpp
+++ b/layers/10_cmdbufemu/main.cpp
@@ -28,7 +28,6 @@
 #include "emulate.h"
 
 const struct _cl_icd_dispatch* g_pNextDispatch = NULL;
-struct SLayerContext* g_pLayerContext = NULL;
 
 static cl_int CL_API_CALL
 clGetDeviceInfo_layer(
@@ -197,10 +196,11 @@ clReleaseEvent_layer(
         &refCount,
         nullptr);
     if (refCount == 1) {
-        auto it = g_pLayerContext->EventMap.find(event);
-        if (it != g_pLayerContext->EventMap.end()) {
+        auto& context = getLayerContext();
+        auto it = context.EventMap.find(event);
+        if (it != context.EventMap.end()) {
             g_pNextDispatch->clReleaseEvent(it->second);
-            g_pLayerContext->EventMap.erase(it);
+            context.EventMap.erase(it);
         }
     }
 
@@ -259,13 +259,6 @@ CL_API_ENTRY cl_int CL_API_CALL clInitLayer(
 
     if (num_entries < dispatchTableSize) {
         return CL_INVALID_VALUE;
-    }
-
-    if (g_pLayerContext == NULL) {
-        g_pLayerContext = new SLayerContext();
-        if (g_pLayerContext == NULL) {
-            return CL_OUT_OF_HOST_MEMORY;
-        }
     }
 
     _init_dispatch();


### PR DESCRIPTION
This PR improves handling for command buffer emulation events.  Specifically:

1. The event type for a command buffer emulation event is now properly returned (`CL_COMMAND_COMMAND_BUFFER_KHR`).
2. Event profiling for the `QUEUED`, `SUBMITTED`, and `START` times is more likely to be accurate.

Note that (2) does require event profiling to be properly implemented for barrier events, and empirically this does not seem to be happening for all OpenCL implementations.