### PR TITLE
animate the OpenGL and Vulkan samples by default

### DIFF
--- a/samples/opengl/00_juliagl/README.md
+++ b/samples/opengl/00_juliagl/README.md
@@ -39,13 +39,14 @@ Note: Many of these command line arguments are identical to the earlier Julia se
 | `--gwy <number>` | 512 | Specify the global work size to execute, in the Y direction.  This also determines the height of the generated image.
 | `--lwx <number>` | 0 | Specify the local work size in the X direction.  If either local works size dimension is zero a `NULL` local work size is used.
 | `--lwy <number>` | 0 | Specify the local work size in the Y direction.  If either local works size dimension is zero a `NULL` local work size is used.
+| `--paused` | n/a | Start with the animation paused.
 
 ## Controls While Running
 
 | Control | Description |
 |:--|:--|
 | `Escape` | Exits from the sample.
-| `Space` | Toggle animation (default: `false`).
+| `Space` | Toggle animation.
 | `V` | Toggle vsync (default: `true`). Disabling vsync may increase framerate but may cause [screen tearing](https://en.wikipedia.org/wiki/Screen_tearing).
 | `A` | Increase the real part of the complex constant `C`.
 | `Z` | Decrease the real part of the complex constant `C`.

--- a/samples/opengl/00_juliagl/main.cpp
+++ b/samples/opengl/00_juliagl/main.cpp
@@ -462,6 +462,7 @@ int main(
     {
         bool hostCopy = false;
         bool hostSync = false;
+        bool paused = false;
 
         popl::OptionParser op("Supported Options");
         op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
@@ -472,6 +473,7 @@ int main(
         op.add<popl::Value<size_t>>("", "gwy", "Global Work Size Y AKA Image Height", gwy, &gwy);
         op.add<popl::Value<size_t>>("", "lwx", "Local Work Size X", lwx, &lwx);
         op.add<popl::Value<size_t>>("", "lwy", "Local Work Size Y", lwy, &lwy);
+        op.add<popl::Switch>("", "paused", "Start with Animation Paused", &paused);
 
         bool printUsage = false;
         try {
@@ -490,6 +492,7 @@ int main(
 
         use_cl_khr_gl_sharing = !hostCopy;
         use_cl_khr_gl_event = !hostSync;
+        animate = !paused;
     }
 
     if (!glfwInit()) {

--- a/samples/opengl/01_nbodygl/README.md
+++ b/samples/opengl/01_nbodygl/README.md
@@ -21,13 +21,14 @@ This example shows how to copy from an OpenCL buffer to OpenGL.
 | `-g` | 0| Specify the local work size.  If the local works size is zero a `NULL` local work size is used.
 | `-w` | 1024 | Specify the render width in pixels.
 | `-h` | 1024 | Specify the render height in pixels.
+| `--paused` | n/a | Start with the animation paused.
 
 ## Controls While Running
 
 | Control | Description |
 |:--|:--|
 | `Escape` | Exits from the sample.
-| `Space` | Toggle animation (default: `false`).
+| `Space` | Toggle animation.
 | `S` | Single-step the simulation.
 | `R` | Re-initialize the simulation.
 | `V` | Toggle vsync (default: `true`). Disabling vsync may increase framerate but may cause [screen tearing](https://en.wikipedia.org/wiki/Screen_tearing).

--- a/samples/opengl/01_nbodygl/main.cpp
+++ b/samples/opengl/01_nbodygl/main.cpp
@@ -253,6 +253,8 @@ int main(
     int deviceIndex = 0;
 
     {
+        bool paused = false;
+
         popl::OptionParser op("Supported Options");
         op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
         op.add<popl::Value<int>>("d", "device", "Device Index", deviceIndex, &deviceIndex);
@@ -260,6 +262,7 @@ int main(
         op.add<popl::Value<size_t>>("g", "groupsize", "Group Size", groupSize, &groupSize);
         op.add<popl::Value<size_t>>("w", "width", "Render Width", width, &width);
         op.add<popl::Value<size_t>>("h", "height", "Render Height", height, &height);
+        op.add<popl::Switch>("", "paused", "Start with Animation Paused", &paused);
 
         bool printUsage = false;
         try {
@@ -275,6 +278,8 @@ int main(
                 "%s", op.help().c_str());
             return -1;
         }
+
+        animate = !paused;
     }
 
     if (!glfwInit()) {

--- a/samples/vulkan/00_juliavk/README.md
+++ b/samples/vulkan/00_juliavk/README.md
@@ -69,13 +69,14 @@ Note: Many of these command line arguments are identical to the earlier Julia se
 | `--lwx <number>` | 0 | Specify the local work size in the X direction.  If either local works size dimension is zero a `NULL` local work size is used.
 | `--lwy <number>` | 0 | Specify the local work size in the Y direction.  If either local works size dimension is zero a `NULL` local work size is used.
 | `--immediate` | n/a | Prefer `VK_PRESENT_MODE_IMMEDIATE_KHR` (no vsync).  May result in faster framerates at the cost of visible tearing.
+| `--paused` | n/a | Start with the animation paused.
 
 ## Controls While Running
 
 | Control | Description |
 |:--|:--|
 | `Escape` | Exits from the sample.
-| `Space` | Toggle animation (default: `false`).
+| `Space` | Toggle animation.
 | `A` | Increase the real part of the complex constant `C`.
 | `Z` | Decrease the real part of the complex constant `C`.
 | `S` | Increase the imaginary part of the complex constant `C`.

--- a/samples/vulkan/00_juliavk/main.cpp
+++ b/samples/vulkan/00_juliavk/main.cpp
@@ -265,6 +265,7 @@ private:
         bool hostSync = false;
         bool noDeviceLocal = false;
         bool immediate = false;
+        bool paused = false;
 
         popl::OptionParser op("Supported Options");
         op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
@@ -278,6 +279,7 @@ private:
         op.add<popl::Value<size_t>>("", "lwx", "Local Work Size X", lwx, &lwx);
         op.add<popl::Value<size_t>>("", "lwy", "Local Work Size Y", lwy, &lwy);
         op.add<popl::Switch>("", "immediate", "Prefer VK_PRESENT_MODE_IMMEDIATE_KHR (no vsync)", &immediate);
+        op.add<popl::Switch>("", "paused", "Start with Animation Paused", &paused);
 
         bool printUsage = false;
         try {
@@ -298,6 +300,7 @@ private:
         useExternalMemory = !hostCopy;
         useExternalSemaphore = !hostSync;
         vsync = !immediate;
+        animate = !paused;
     }
 
     void initWindow() {

--- a/samples/vulkan/01_nbodyvk/README.md
+++ b/samples/vulkan/01_nbodyvk/README.md
@@ -65,13 +65,14 @@ Note: Many of these command line arguments are identical to the earlier Julia se
 | `-g` | 0| Specify the local work size.  If the local work size is zero a `NULL` local work size is used.
 | `-w` | 1024 | Specify the render width in pixels.
 | `-h` | 1024 | Specify the render height in pixels.
+| `--paused` | n/a | Start with the animation paused.
 
 ## Controls While Running
 
 | Control | Description |
 |:--|:--|
 | `Escape` | Exits from the sample.
-| `Space` | Toggle animation (default: `false`).
+| `Space` | Toggle animation.
 | `S` | Single-step the simulation.
 
 ## How to Generate Vulkan SPIR-V Files

--- a/samples/vulkan/01_nbodyvk/main.cpp
+++ b/samples/vulkan/01_nbodyvk/main.cpp
@@ -253,6 +253,7 @@ private:
         bool hostSync = false;
         bool noDeviceLocal = false;
         bool immediate = false;
+        bool paused = false;
 
         popl::OptionParser op("Supported Options");
         op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
@@ -265,6 +266,7 @@ private:
         op.add<popl::Value<size_t>>("w", "width", "Render Width", width, &width);
         op.add<popl::Value<size_t>>("h", "height", "Render Height", height, &height);
         op.add<popl::Switch>("", "immediate", "Prefer VK_PRESENT_MODE_IMMEDIATE_KHR (no vsync)", &immediate);
+        op.add<popl::Switch>("", "paused", "Start with Animation Paused", &paused);
 
         bool printUsage = false;
         try {
@@ -285,6 +287,7 @@ private:
         useExternalMemory = !hostCopy;
         useExternalSemaphore = !hostSync;
         vsync = !immediate;
+        animate = !paused;
     }
 
     void initWindow() {


### PR DESCRIPTION
Animate the OpenGL and Vulkan samples by default, but add an option to start with animation paused if desired.