### PR TITLE
properly refcount objects used by command buffers

### DIFF
--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -211,8 +211,9 @@ struct BarrierWithWaitList : Command
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue)
     {
-        auto ret = new BarrierWithWaitList(cmdbuf, queue);
-        return std::unique_ptr<BarrierWithWaitList>(ret);
+        auto ret = std::unique_ptr<BarrierWithWaitList>(
+            new BarrierWithWaitList(cmdbuf, queue));
+        return ret;
     }
 
     int playback(
@@ -245,7 +246,8 @@ struct CopyBuffer : Command
         size_t dst_offset,
         size_t size)
     {
-        auto ret = new CopyBuffer(cmdbuf, queue);
+        auto ret = std::unique_ptr<CopyBuffer>(
+            new CopyBuffer(cmdbuf, queue));
 
         ret->src_buffer = src_buffer;
         ret->dst_buffer = dst_buffer;
@@ -256,7 +258,7 @@ struct CopyBuffer : Command
         g_pNextDispatch->clRetainMemObject(ret->src_buffer);
         g_pNextDispatch->clRetainMemObject(ret->dst_buffer);
 
-        return std::unique_ptr<CopyBuffer>(ret);
+        return ret;
     }
 
     ~CopyBuffer()
@@ -310,7 +312,8 @@ struct CopyBufferRect : Command
         size_t dst_row_pitch,
         size_t dst_slice_pitch)
     {
-        auto ret = new CopyBufferRect(cmdbuf, queue);
+        auto ret = std::unique_ptr<CopyBufferRect>(
+            new CopyBufferRect(cmdbuf, queue));
 
         ret->src_buffer = src_buffer;
         ret->dst_buffer = dst_buffer;
@@ -325,7 +328,7 @@ struct CopyBufferRect : Command
         g_pNextDispatch->clRetainMemObject(ret->src_buffer);
         g_pNextDispatch->clRetainMemObject(ret->dst_buffer);
 
-        return std::unique_ptr<CopyBufferRect>(ret);
+        return ret;
     }
 
     ~CopyBufferRect()
@@ -383,7 +386,8 @@ struct CopyBufferToImage : Command
         const size_t* dst_origin,
         const size_t* region)
     {
-        auto ret = new CopyBufferToImage(cmdbuf, queue);
+        auto ret = std::unique_ptr<CopyBufferToImage>(
+            new CopyBufferToImage(cmdbuf, queue));
 
         ret->src_buffer = src_buffer;
         ret->dst_image = dst_image;
@@ -394,7 +398,7 @@ struct CopyBufferToImage : Command
         g_pNextDispatch->clRetainMemObject(ret->src_buffer);
         g_pNextDispatch->clRetainMemObject(ret->dst_image);
 
-        return std::unique_ptr<CopyBufferToImage>(ret);
+        return ret;
     }
 
     ~CopyBufferToImage()
@@ -444,7 +448,8 @@ struct CopyImage : Command
         const size_t* dst_origin,
         const size_t* region)
     {
-        auto ret = new CopyImage(cmdbuf, queue);
+        auto ret = std::unique_ptr<CopyImage>(
+            new CopyImage(cmdbuf, queue));
 
         ret->src_image = src_image;
         ret->dst_image = dst_image;
@@ -455,7 +460,7 @@ struct CopyImage : Command
         g_pNextDispatch->clRetainMemObject(ret->src_image);
         g_pNextDispatch->clRetainMemObject(ret->dst_image);
 
-        return std::unique_ptr<CopyImage>(ret);
+        return ret;
     }
 
     ~CopyImage()
@@ -500,7 +505,8 @@ struct CopyImageToBuffer : Command
         const size_t* region,
         size_t dst_offset)
     {
-        auto ret = new CopyImageToBuffer(cmdbuf, queue);
+        auto ret = std::unique_ptr<CopyImageToBuffer>(
+            new CopyImageToBuffer(cmdbuf, queue));
 
         ret->src_image = src_image;
         ret->dst_buffer = dst_buffer;
@@ -511,7 +517,7 @@ struct CopyImageToBuffer : Command
         g_pNextDispatch->clRetainMemObject(ret->src_image);
         g_pNextDispatch->clRetainMemObject(ret->dst_buffer);
 
-        return std::unique_ptr<CopyImageToBuffer>(ret);
+        return ret;
     }
 
     ~CopyImageToBuffer()
@@ -561,7 +567,8 @@ struct FillBuffer : Command
         size_t offset,
         size_t size)
     {
-        auto ret = new FillBuffer(cmdbuf, queue);
+        auto ret = std::unique_ptr<FillBuffer>(
+            new FillBuffer(cmdbuf, queue));
 
         ret->buffer = buffer;
 
@@ -577,7 +584,7 @@ struct FillBuffer : Command
 
         g_pNextDispatch->clRetainMemObject(ret->buffer);
 
-        return std::unique_ptr<FillBuffer>(ret);
+        return ret;
     }
 
     ~FillBuffer()
@@ -624,7 +631,8 @@ struct FillImage : Command
         const size_t* origin,
         const size_t* region)
     {
-        auto ret = new FillImage(cmdbuf, queue);
+        auto ret = std::unique_ptr<FillImage>(
+            new FillImage(cmdbuf, queue));
 
         ret->image = image;
 
@@ -648,7 +656,7 @@ struct FillImage : Command
 
         g_pNextDispatch->clRetainMemObject(ret->image);
 
-        return std::unique_ptr<FillImage>(ret);
+        return ret;
     }
 
     ~FillImage()
@@ -686,7 +694,7 @@ private:
 
 struct NDRangeKernel : Command
 {
-    static cl_int create(
+    static std::unique_ptr<NDRangeKernel> create(
         const cl_ndrange_kernel_command_properties_khr* properties,
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
@@ -695,9 +703,9 @@ struct NDRangeKernel : Command
         const size_t* global_work_offset,
         const size_t* global_work_size,
         const size_t* local_work_size,
-        NDRangeKernel*& command)
+        cl_int& errorCode)
     {
-        cl_int errorCode = CL_SUCCESS;
+        errorCode = CL_SUCCESS;
 
         ptrdiff_t numProperties = 0;
 #if defined(cl_khr_command_buffer_mutable_dispatch)
@@ -717,7 +725,8 @@ struct NDRangeKernel : Command
                 case CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR:
                     if( found_CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR )
                     {
-                        return CL_INVALID_VALUE;
+                        errorCode = CL_INVALID_VALUE;
+                        return nullptr;
                     }
                     else
                     {
@@ -728,14 +737,15 @@ struct NDRangeKernel : Command
                     break;
 #endif
                 default:
-                    return  CL_INVALID_VALUE;
-                    break;
+                    errorCode = CL_INVALID_VALUE;
+                    return nullptr;
                 }
             }
             numProperties = check - properties + 1;
         }
 
-        command = new NDRangeKernel(cmdbuf, queue);
+        auto command = std::unique_ptr<NDRangeKernel>(
+            new NDRangeKernel(cmdbuf, queue));
 
         command->kernel = g_pNextDispatch->clCloneKernel(kernel, NULL);
         command->work_dim = work_dim;
@@ -777,7 +787,7 @@ struct NDRangeKernel : Command
                 local_work_size + work_dim);
         }
 
-        return CL_SUCCESS;
+        return command;
     }
 
     ~NDRangeKernel()
@@ -1293,8 +1303,6 @@ typedef struct _cl_command_buffer_khr
             wait_list,
             syncPoint);
 
-        Commands.push_back(std::move(command));
-
         if( sync_point != nullptr )
         {
             sync_point[0] = syncPoint;
@@ -1303,6 +1311,8 @@ typedef struct _cl_command_buffer_khr
         {
             mutable_handle[0] = command.get();
         }
+
+        Commands.push_back(std::move(command));
     }
 
     cl_int  finalize()
@@ -1945,23 +1955,24 @@ cl_int CL_API_CALL clCommandNDRangeKernelKHR_EMU(
         return errorCode;
     }
 
-    NDRangeKernel* command = NULL;
-    if( cl_int errorCode = NDRangeKernel::create(
-            properties,
-            cmdbuf,
-            command_queue,
-            kernel,
-            work_dim,
-            global_work_offset,
-            global_work_size,
-            local_work_size,
-            command) )
+    cl_int errorCode = CL_SUCCESS;
+    auto command = NDRangeKernel::create(
+        properties,
+        cmdbuf,
+        command_queue,
+        kernel,
+        work_dim,
+        global_work_offset,
+        global_work_size,
+        local_work_size,
+        errorCode);
+    if( errorCode )
     {
         return errorCode;
     }
 
     cmdbuf->addCommand(
-        std::unique_ptr<NDRangeKernel>(command),
+        std::move(command),
         num_sync_points_in_wait_list,
         sync_point_wait_list,
         sync_point,

--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -206,12 +207,12 @@ private:
 
 struct BarrierWithWaitList : Command
 {
-    static BarrierWithWaitList* create(
+    static std::unique_ptr<BarrierWithWaitList> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue)
     {
         auto ret = new BarrierWithWaitList(cmdbuf, queue);
-        return ret;
+        return std::unique_ptr<BarrierWithWaitList>(ret);
     }
 
     int playback(
@@ -235,7 +236,7 @@ private:
 
 struct CopyBuffer : Command
 {
-    static CopyBuffer* create(
+    static std::unique_ptr<CopyBuffer> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem src_buffer,
@@ -252,7 +253,16 @@ struct CopyBuffer : Command
         ret->dst_offset = dst_offset;
         ret->size = size;
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->src_buffer);
+        g_pNextDispatch->clRetainMemObject(ret->dst_buffer);
+
+        return std::unique_ptr<CopyBuffer>(ret);
+    }
+
+    ~CopyBuffer()
+    {
+        g_pNextDispatch->clReleaseMemObject(src_buffer);
+        g_pNextDispatch->clReleaseMemObject(dst_buffer);
     }
 
     int playback(
@@ -287,7 +297,7 @@ private:
 
 struct CopyBufferRect : Command
 {
-    static CopyBufferRect* create(
+    static std::unique_ptr<CopyBufferRect> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem src_buffer,
@@ -312,7 +322,16 @@ struct CopyBufferRect : Command
         ret->dst_row_pitch = dst_row_pitch;
         ret->dst_slice_pitch = dst_slice_pitch;
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->src_buffer);
+        g_pNextDispatch->clRetainMemObject(ret->dst_buffer);
+
+        return std::unique_ptr<CopyBufferRect>(ret);
+    }
+
+    ~CopyBufferRect()
+    {
+        g_pNextDispatch->clReleaseMemObject(src_buffer);
+        g_pNextDispatch->clReleaseMemObject(dst_buffer);
     }
 
     int playback(
@@ -355,7 +374,7 @@ private:
 
 struct CopyBufferToImage : Command
 {
-    static CopyBufferToImage* create(
+    static std::unique_ptr<CopyBufferToImage> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem src_buffer,
@@ -372,7 +391,16 @@ struct CopyBufferToImage : Command
         std::copy(dst_origin, dst_origin + 3, ret->dst_origin.begin());
         std::copy(region, region + 3, ret->region.begin());
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->src_buffer);
+        g_pNextDispatch->clRetainMemObject(ret->dst_image);
+
+        return std::unique_ptr<CopyBufferToImage>(ret);
+    }
+
+    ~CopyBufferToImage()
+    {
+        g_pNextDispatch->clReleaseMemObject(src_buffer);
+        g_pNextDispatch->clReleaseMemObject(dst_image);
     }
 
     int playback(
@@ -407,7 +435,7 @@ private:
 
 struct CopyImage : Command
 {
-    static CopyImage* create(
+    static std::unique_ptr<CopyImage> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem src_image,
@@ -424,7 +452,16 @@ struct CopyImage : Command
         std::copy(dst_origin, dst_origin + 3, ret->dst_origin.begin());
         std::copy(region, region + 3, ret->region.begin());
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->src_image);
+        g_pNextDispatch->clRetainMemObject(ret->dst_image);
+
+        return std::unique_ptr<CopyImage>(ret);
+    }
+
+    ~CopyImage()
+    {
+        g_pNextDispatch->clReleaseMemObject(src_image);
+        g_pNextDispatch->clReleaseMemObject(dst_image);
     }
 
     int playback(
@@ -454,7 +491,7 @@ private:
 
 struct CopyImageToBuffer : Command
 {
-    static CopyImageToBuffer* create(
+    static std::unique_ptr<CopyImageToBuffer> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem src_image,
@@ -471,7 +508,16 @@ struct CopyImageToBuffer : Command
         std::copy(region, region + 3, ret->region.begin());
         ret->dst_offset = dst_offset;
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->src_image);
+        g_pNextDispatch->clRetainMemObject(ret->dst_buffer);
+
+        return std::unique_ptr<CopyImageToBuffer>(ret);
+    }
+
+    ~CopyImageToBuffer()
+    {
+        g_pNextDispatch->clReleaseMemObject(src_image);
+        g_pNextDispatch->clReleaseMemObject(dst_buffer);
     }
 
     int playback(
@@ -506,7 +552,7 @@ private:
 
 struct FillBuffer : Command
 {
-    static FillBuffer* create(
+    static std::unique_ptr<FillBuffer> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem buffer,
@@ -529,7 +575,14 @@ struct FillBuffer : Command
         ret->offset = offset;
         ret->size = size;
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->buffer);
+
+        return std::unique_ptr<FillBuffer>(ret);
+    }
+
+    ~FillBuffer()
+    {
+        g_pNextDispatch->clReleaseMemObject(buffer);
     }
 
     int playback(
@@ -563,7 +616,7 @@ private:
 
 struct FillImage : Command
 {
-    static FillImage* create(
+    static std::unique_ptr<FillImage> create(
         cl_command_buffer_khr cmdbuf,
         cl_command_queue queue,
         cl_mem image,
@@ -593,7 +646,14 @@ struct FillImage : Command
         std::copy(origin, origin + 3, ret->origin.begin());
         std::copy(region, region + 3, ret->region.begin());
 
-        return ret;
+        g_pNextDispatch->clRetainMemObject(ret->image);
+
+        return std::unique_ptr<FillImage>(ret);
+    }
+
+    ~FillImage()
+    {
+        g_pNextDispatch->clReleaseMemObject(image);
     }
 
     int playback(
@@ -718,6 +778,11 @@ struct NDRangeKernel : Command
         }
 
         return CL_SUCCESS;
+    }
+
+    ~NDRangeKernel()
+    {
+        g_pNextDispatch->clReleaseKernel(kernel);
     }
 
 #if defined(cl_khr_command_buffer_mutable_dispatch)
@@ -1034,8 +1099,22 @@ typedef struct _cl_command_buffer_khr
                 cmdbuf->Properties.begin(),
                 properties,
                 properties + numProperties );
+
+            for( auto queue : cmdbuf->Queues )
+            {
+                g_pNextDispatch->clRetainCommandQueue(queue);
+            }
         }
+
         return cmdbuf;
+    }
+
+    ~_cl_command_buffer_khr()
+    {
+        for( auto queue : Queues )
+        {
+            g_pNextDispatch->clReleaseCommandQueue(queue);
+        }
     }
 
     static bool isValid( cl_command_buffer_khr cmdbuf )
@@ -1198,7 +1277,7 @@ typedef struct _cl_command_buffer_khr
     }
 
     void    addCommand(
-                Command* command,
+                std::unique_ptr<Command> command,
                 cl_uint num_sync_points,
                 const cl_sync_point_khr* wait_list,
                 cl_sync_point_khr* sync_point,
@@ -1214,7 +1293,7 @@ typedef struct _cl_command_buffer_khr
             wait_list,
             syncPoint);
 
-        Commands.push_back(command);
+        Commands.push_back(std::move(command));
 
         if( sync_point != nullptr )
         {
@@ -1222,7 +1301,7 @@ typedef struct _cl_command_buffer_khr
         }
         if( mutable_handle != nullptr )
         {
-            mutable_handle[0] = command;
+            mutable_handle[0] = command.get();
         }
     }
 
@@ -1245,7 +1324,7 @@ typedef struct _cl_command_buffer_khr
         const uint32_t numSyncPoints = NextSyncPoint.load(std::memory_order_relaxed);
         std::vector<cl_event> deps(numSyncPoints, nullptr);
 
-        for( auto command : Commands )
+        for( const auto& command : Commands )
         {
             errorCode = command->playback(queue, deps);
             if( errorCode != CL_SUCCESS )
@@ -1342,7 +1421,7 @@ private:
     cl_command_buffer_flags_khr Flags;
     std::atomic<uint32_t> RefCount;
 
-    std::vector<Command*> Commands;
+    std::vector<std::unique_ptr<Command>> Commands;
     std::atomic<uint32_t> NextSyncPoint;
 
     _cl_command_buffer_khr(cl_command_buffer_flags_khr flags) :
@@ -1882,7 +1961,7 @@ cl_int CL_API_CALL clCommandNDRangeKernelKHR_EMU(
     }
 
     cmdbuf->addCommand(
-        command,
+        std::unique_ptr<NDRangeKernel>(command),
         num_sync_points_in_wait_list,
         sync_point_wait_list,
         sync_point,


### PR DESCRIPTION
Add proper reference counting for OpenCL objects that are used by command buffers.

See: https://github.com/KhronosGroup/OpenCL-Docs/pull/885