### PR TITLE
do not pass vectors of devices by value

### DIFF
--- a/samples/00_enumopenclpp/main.cpp
+++ b/samples/00_enumopenclpp/main.cpp
@@ -50,7 +50,7 @@ static void PrintDeviceType(
 }
 
 static cl_int PrintDeviceInfoSummary(
-    const std::vector<cl::Device> devices )
+    const std::vector<cl::Device>& devices )
 {
     for( size_t i = 0; i < devices.size(); i++ )
     {

--- a/samples/00_enumqueuefamilies/main.cpp
+++ b/samples/00_enumqueuefamilies/main.cpp
@@ -88,7 +88,7 @@ static void PrintPlatformInfoSummary(
 }
 
 static void PrintDeviceInfoSummary(
-    const std::vector<cl::Device> devices )
+    const std::vector<cl::Device>& devices )
 {
     size_t  i = 0;
     for( i = 0; i < devices.size(); i++ )

--- a/samples/00_extendeddevicequeries/main.cpp
+++ b/samples/00_extendeddevicequeries/main.cpp
@@ -60,7 +60,7 @@ static void PrintPlatformInfoSummary(
 }
 
 static void PrintDeviceInfoSummary(
-    const std::vector<cl::Device> devices )
+    const std::vector<cl::Device>& devices )
 {
     size_t  i = 0;
     for( i = 0; i < devices.size(); i++ )

--- a/samples/00_newqueriespp/main.cpp
+++ b/samples/00_newqueriespp/main.cpp
@@ -108,7 +108,7 @@ static void PrintDeviceDeviceEnqueueCapabilities(
 #endif
 
 static void PrintDeviceInfoSummary(
-    const std::vector<cl::Device> devices )
+    const std::vector<cl::Device>& devices )
 {
     size_t  i = 0;
     for( i = 0; i < devices.size(); i++ )


### PR DESCRIPTION
In a few samples a vector of devices was being passed by value, which is inefficient.  Pass by reference, instead.