### PR TITLE
a few command buffer layer fixes

### DIFF
--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -1209,6 +1209,30 @@ typedef struct _cl_command_buffer_khr
                     ptr );
             }
             break;
+#if defined(CL_COMMAND_BUFFER_CONTEXT_KHR)
+        // This enum was not in the original specification so some headers may
+        // not have it.
+        case CL_COMMAND_BUFFER_CONTEXT_KHR:
+            {
+                cl_context context = nullptr;
+                if( cl_int errorCode = g_pNextDispatch->clGetCommandQueueInfo(
+                        getQueue(),
+                        CL_QUEUE_CONTEXT,
+                        sizeof(context),
+                        &context,
+                        nullptr) )
+                {
+                    return errorCode;
+                }
+                auto ptr = (cl_context*)param_value;
+                return writeParamToMemory(
+                    param_value_size,
+                    context,
+                    param_value_size_ret,
+                    ptr );
+            }
+            break;
+#endif
         default:
             break;
         }

--- a/samples/12_commandbuffers/main.cpp
+++ b/samples/12_commandbuffers/main.cpp
@@ -12,6 +12,11 @@
 
 #include "util.hpp"
 
+// This is a new enum that might not be in all headers yet.
+#ifndef CL_COMMAND_BUFFER_CONTEXT_KHR
+#define CL_COMMAND_BUFFER_CONTEXT_KHR 0x1299
+#endif
+
 const size_t    gwx = 1024*1024;
 
 static const char kernelString[] = R"CLC(
@@ -199,6 +204,17 @@ int main(
         printf("\t\tCL_COMMAND_BUFFER_QUEUES_KHR: %p (%s)\n",
             testQueue,
             testQueue == commandQueue() ? "matches" : "MISMATCH!");
+
+        cl_context testContext = NULL;
+        clGetCommandBufferInfoKHR(
+            cmdbuf,
+            CL_COMMAND_BUFFER_CONTEXT_KHR,
+            sizeof(testContext),
+            &testContext,
+            NULL );
+        printf("\t\tCL_COMMAND_BUFFER_CONEXT: %p (%s)\n",
+            testContext,
+            testContext == context() ? "matches" : "MISMATCH!");
 
         cl_uint refCount = 0;
         clGetCommandBufferInfoKHR(

--- a/samples/13_mutablecommandbuffers/main.cpp
+++ b/samples/13_mutablecommandbuffers/main.cpp
@@ -329,6 +329,17 @@ int main(
             &type,
             NULL );
         printf("\t\tCL_MUTABLE_COMMAND_COMMAND_TYPE_KHR: %u\n", type);
+
+        cl_kernel testKernel = NULL;
+        clGetMutableCommandInfoKHR(
+            command,
+            CL_MUTABLE_DISPATCH_KERNEL_KHR,
+            sizeof(testKernel),
+            &testKernel,
+            NULL );
+        printf("\t\tCL_MUTABLE_DISPATCH_KERNEL_KHR: %p (%s)\n",
+            testKernel,
+            testKernel == kernel() ? "matches" : "MISMATCH!" );
     }
 
     clFinalizeCommandBufferKHR(cmdbuf);


### PR DESCRIPTION
* Keeps the original kernel handle around for mutable dispatch querying purposes.
    * Fixes https://github.com/bashbaug/SimpleOpenCLSamples/issues/79
* Adds support for the new `CL_COMMAND_BUFFER_CONTEXT_KHR` query.  See:
    * https://github.com/KhronosGroup/OpenCL-Docs/issues/898
    * https://github.com/KhronosGroup/OpenCL-Headers/pull/226