### PR TITLE
properly handle the case when multiple layers are enabled

### DIFF
--- a/layers/10_cmdbufemu/main.cpp
+++ b/layers/10_cmdbufemu/main.cpp
@@ -124,14 +124,8 @@ clGetExtensionFunctionAddressForPlatform_layer(
     cl_platform_id platform,
     const char *   func_name)
 {
-    void* ret = g_pNextDispatch->clGetExtensionFunctionAddressForPlatform(
-        platform,
-        func_name);
-
-    if (ret) {
-        return ret;
-    }
-
+    // For now, prefer the emulated functions, even if the extension is
+    // supported natively.  Eventually this should become smarter.
     CHECK_RETURN_EXTENSION_FUNCTION( clCreateCommandBufferKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clFinalizeCommandBufferKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clRetainCommandBufferKHR );
@@ -157,7 +151,9 @@ clGetExtensionFunctionAddressForPlatform_layer(
     CHECK_RETURN_EXTENSION_FUNCTION( clGetMutableCommandInfoKHR );
 #endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
-    return nullptr;
+    return g_pNextDispatch->clGetExtensionFunctionAddressForPlatform(
+        platform,
+        func_name);
 }
 
 static cl_int CL_API_CALL

--- a/layers/11_semaemu/main.cpp
+++ b/layers/11_semaemu/main.cpp
@@ -100,14 +100,8 @@ clGetExtensionFunctionAddressForPlatform_layer(
     cl_platform_id platform,
     const char *   func_name)
 {
-    void* ret = g_pNextDispatch->clGetExtensionFunctionAddressForPlatform(
-        platform,
-        func_name);
-
-    //if (ret) {
-    //    return ret;
-    //}
-
+    // For now, prefer the emulated functions, even if the extension is
+    // supported natively.  Eventually this should become smarter.
     CHECK_RETURN_EXTENSION_FUNCTION( clCreateSemaphoreWithPropertiesKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clEnqueueWaitSemaphoresKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clEnqueueSignalSemaphoresKHR );
@@ -115,7 +109,9 @@ clGetExtensionFunctionAddressForPlatform_layer(
     CHECK_RETURN_EXTENSION_FUNCTION( clRetainSemaphoreKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clReleaseSemaphoreKHR );
 
-    return nullptr;
+    return g_pNextDispatch->clGetExtensionFunctionAddressForPlatform(
+        platform,
+        func_name);
 }
 
 static cl_int CL_API_CALL

--- a/samples/12_commandbuffers/main.cpp
+++ b/samples/12_commandbuffers/main.cpp
@@ -212,7 +212,7 @@ int main(
             sizeof(testContext),
             &testContext,
             NULL );
-        printf("\t\tCL_COMMAND_BUFFER_CONEXT: %p (%s)\n",
+        printf("\t\tCL_COMMAND_BUFFER_CONTEXT: %p (%s)\n",
             testContext,
             testContext == context() ? "matches" : "MISMATCH!");
 


### PR DESCRIPTION
Handle the case where multiple layers are enabled by chaining calls to clGetExtensionFunctionAddressForPlatform.

Currently, this will always return the emulated functions preferentially, though eventually this will need to become smarter.

Also fixes a minor typo.