### PR TITLE
fix extendeddevicequeries typo

### DIFF
--- a/samples/00_extendeddevicequeries/main.cpp
+++ b/samples/00_extendeddevicequeries/main.cpp
@@ -171,7 +171,7 @@ static void PrintDeviceInfoSummary(
                 pciInfo.pci_device,
                 pciInfo.pci_function);
         } else {
-            printf("\tThis device does not support cl_khr_device_uuid.\n");
+            printf("\tThis device does not support cl_khr_pci_bus_info.\n");
         }
     }
 }


### PR DESCRIPTION
Fix a copy-paste typo affecting the error message when cl_khr_pci_bus_info is not supported.