### PR TITLE
set minimal permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Follows best practices by setting minimal permissions for GitHub actions.