### PR TITLE
update python requirements

### DIFF
--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,10 +1,6 @@
-matplotlib<3.4
-numpy==1.22.0
-pyopencl==2021.1.6
-Pillow==10.0.1
+matplotlib==3.8.2
+numpy==1.26.3
+pyopencl==2023.1.4
+pillow==10.2.0
 
-jupyterlab
-
-ipython==7.10.*
-ipykernel==5.*
-
+jupyterlab==4.0.10


### PR DESCRIPTION
We do not need to explicitly list ipython or ipykernel since they are already dependencies of jupyterlab.