### PR TITLE
call the CommandQueue constructor directly

### DIFF
--- a/samples/01_copybuffer/main.cpp
+++ b/samples/01_copybuffer/main.cpp
@@ -51,7 +51,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
    cl::Buffer deviceMemSrc = cl::Buffer{
         context,

--- a/samples/02_copybufferkernel/main.cpp
+++ b/samples/02_copybufferkernel/main.cpp
@@ -59,7 +59,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/03_mandelbrot/main.cpp
+++ b/samples/03_mandelbrot/main.cpp
@@ -93,7 +93,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/04_julia/main.cpp
+++ b/samples/04_julia/main.cpp
@@ -114,7 +114,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/04_sobel/main.cpp
+++ b/samples/04_sobel/main.cpp
@@ -161,7 +161,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/05_kernelfromfile/main.cpp
+++ b/samples/05_kernelfromfile/main.cpp
@@ -81,7 +81,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     printf("Reading program source from file: %s\n", fileName.c_str() );
     std::string kernelString = readStringFromFile(fileName.c_str());

--- a/samples/05_spirvkernelfromfile/main.cpp
+++ b/samples/05_spirvkernelfromfile/main.cpp
@@ -164,7 +164,7 @@ int main(
     }
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     printf("Reading SPIR-V from file: %s\n", fileName.c_str());
     std::vector<cl_uchar> spirv = readSPIRVFromFile(fileName);

--- a/samples/06_ndrangekernelfromfile/main.cpp
+++ b/samples/06_ndrangekernelfromfile/main.cpp
@@ -96,7 +96,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     printf("Reading program source from file: %s\n", fileName.c_str() );
     std::string kernelString = readStringFromFile(fileName.c_str());

--- a/samples/11_semaphores/main.cpp
+++ b/samples/11_semaphores/main.cpp
@@ -102,8 +102,8 @@ int main(
     PrintSemaphoreTypes(deviceSemaphoreTypes);
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue q0 = cl::CommandQueue{context, devices[deviceIndex]};
-    cl::CommandQueue q1 = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue q0{context, devices[deviceIndex]};
+    cl::CommandQueue q1{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/12_commandbuffers/main.cpp
+++ b/samples/12_commandbuffers/main.cpp
@@ -140,7 +140,7 @@ int main(
     PrintCommandBufferRequiredQueueProperties(requiredProps);
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/12_commandbufferspp/main.cpp
+++ b/samples/12_commandbufferspp/main.cpp
@@ -123,7 +123,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR>());
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/13_mutablecommandbuffers/main.cpp
+++ b/samples/13_mutablecommandbuffers/main.cpp
@@ -175,7 +175,7 @@ int main(
     PrintMutableDispatchCapabilities(mutableCaps);
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/usm/100_dmemhelloworld/main.cpp
+++ b/samples/usm/100_dmemhelloworld/main.cpp
@@ -58,7 +58,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/usm/200_hmemhelloworld/main.cpp
+++ b/samples/usm/200_hmemhelloworld/main.cpp
@@ -58,7 +58,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/usm/300_smemhelloworld/main.cpp
+++ b/samples/usm/300_smemhelloworld/main.cpp
@@ -58,7 +58,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/usm/310_usmmigratemem/main.cpp
+++ b/samples/usm/310_usmmigratemem/main.cpp
@@ -58,7 +58,7 @@ int main(
         devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();

--- a/samples/usm/400_sysmemhelloworld/main.cpp
+++ b/samples/usm/400_sysmemhelloworld/main.cpp
@@ -72,7 +72,7 @@ int main(
     }
 
     cl::Context context{devices[deviceIndex]};
-    cl::CommandQueue commandQueue = cl::CommandQueue{context, devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
 
     cl::Program program{ context, kernelString };
     program.build();


### PR DESCRIPTION
Call the CommandQueue constructor directly instead of constructing a new CommandQueue and assigning it using the assignment operator.