### PR TITLE
add more supported flags for validation

### DIFF
--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -1248,7 +1248,14 @@ typedef struct _cl_command_buffer_khr
         cl_command_buffer_flags_khr flags )
     {
         const cl_command_buffer_flags_khr allFlags =
-            CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR;
+            CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR |
+#if defined(cl_khr_command_buffer_mutable_dispatch)
+            CL_COMMAND_BUFFER_MUTABLE_KHR |
+#endif // defined(cl_khr_command_buffer_mutable_dispatch)
+#if defined(cl_khr_command_buffer_multi_device) && 0
+            CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR |
+#endif // defined(cl_khr_command_buffer_multi_device)
+            0;
         if( flags & ~allFlags )
         {
             return CL_INVALID_VALUE;


### PR DESCRIPTION
PR #110 added support for validating command buffer ceration flags but missed a few flags for mutable dispatch.  This PR adds the missing flags.

The command buffer emulation layer doesn't support `cl_khr_command_buffer_multi_device` yet, which is why the `CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR` flags is not enabled currently.