### PR TITLE
add a float atomics sample

### DIFF
--- a/include/CL/opencl.hpp
+++ b/include/CL/opencl.hpp
@@ -1799,6 +1799,12 @@ CL_HPP_DECLARE_PARAM_TRAITS_(cl_mutable_command_info_khr, CL_MUTABLE_DISPATCH_LO
 CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR, cl_device_kernel_clock_capabilities_khr)
 #endif /* cl_khr_kernel_clock */
 
+#if defined(cl_ext_float_atomics)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT, cl_device_fp_atomic_capabilities_ext)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT, cl_device_fp_atomic_capabilities_ext)
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT, cl_device_fp_atomic_capabilities_ext)
+#endif /* cl_ext_float_atomics */
+
 #if defined(cl_intel_command_queue_families)
 CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(CL_HPP_DECLARE_PARAM_TRAITS_)
 #endif // cl_intel_command_queue_families

--- a/samples/16_floatatomics/CMakeLists.txt
+++ b/samples/16_floatatomics/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2019-2024 Ben Ashbaugh
+#
+# SPDX-License-Identifier: MIT
+
+add_opencl_sample(
+    TEST
+    NUMBER 16
+    TARGET floatatomics
+    VERSION 120
+    SOURCES main.cpp)

--- a/samples/16_floatatomics/CMakeLists.txt
+++ b/samples/16_floatatomics/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 Ben Ashbaugh
+# Copyright (c) 2024 Ben Ashbaugh
 #
 # SPDX-License-Identifier: MIT
 

--- a/samples/16_floatatomics/README.md
+++ b/samples/16_floatatomics/README.md
@@ -1,0 +1,21 @@
+# Floating-point Atomic Adds
+
+## Sample Purpose
+
+TODO
+
+Inspired by: https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html
+
+## Key APIs and Concepts
+
+TODO
+
+## Command Line Options
+
+| Option | Default Value | Description |
+|:--|:-:|:--|
+| `-d <index>` | 0 | Specify the index of the OpenCL device in the platform to execute on the sample on.
+| `-p <index>` | 0 | Specify the index of the OpenCL platform to execute the sample on.
+| `-i <number>` | 16 | Specify the number of iterations to execute.
+| `--gwx <number>` | 1024 | Specify the global work size to execute, which is also the number of floating-point atomics to perform.
+| `-e` | N/A | Unconditionally use the emulated floating-point atomic add.

--- a/samples/16_floatatomics/README.md
+++ b/samples/16_floatatomics/README.md
@@ -2,26 +2,31 @@
 
 ## Sample Purpose
 
-This is an advanced sample that demonstrates how to do atomic floating-point atomic addition in a kernel.
-The most standard way to perform floating-point atomic addition uses the [cl_ext_float_atomics](https://registry.khronos.org/OpenCL/extensions/ext/cl_ext_float_atomics.html) extension.
+This is an advanced sample that demonstrates how to do atomic floating-point addition in a kernel.
+The most standard way to perform atomic floating-point addition uses the [cl_ext_float_atomics](https://registry.khronos.org/OpenCL/extensions/ext/cl_ext_float_atomics.html) extension.
 This extension adds device queries and built-in functions to optionally support floating-point atomic add, min, max, load, and store on 16-bit, 32-bit, and 64-bit floating-point types.
-When the `cl_ext_float_atomics` extenison is supported, and 32-bit floating point atomic adds are supported, this sample will use the built-in functions added by this extension.
+When the `cl_ext_float_atomics` extension is supported, and 32-bit floating point atomic adds are supported, this sample will use the built-in functions added by this extension.
 
-This sample also fallback implentations when the `cl_ext_float_atomics` extension is not supported:
+This sample also includes fallback implementations when the `cl_ext_float_atomics` extension is not supported:
 
 * For NVIDIA GPUs, this sample includes a fallback that does the floating-point atomic add using inline PTX assembly language.
 * For AMD GPUs, this sample includes a fallback that calls a compiler intrinsic to do the floating-point atomic add.
-* For other devices, this sample includes a fallback that emulates the floating-point atomic add using 32-bit `atomic_xchg` functions.
-This fallback implementation cannot reliably return the "old" value that was in memory before performing the atomic add, so it is unsuitable for all usages, but it does work for some important uses-cases, such as reductions.
+* For other devices, this sample includes two fallback implementations:
+    * The first emulates the floating-point atomic add using 32-bit `atomic_xchg` functions.
+      This fallback implementation cannot reliably return the "old" value that was in memory before performing the atomic add, so it is unsuitable for all usages, but it does work for some important uses-cases, such as reductions.
+    * The second emulates the floating-point atomic add using 32-bit `atomic_cmpxchg` functions.
+      This is a slower emulation, but it is able to reliably return the "old" value that was in memory before performing the atomic add.
 
 This sample was inspired by the blog post: https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html
 
 ## Key APIs and Concepts
 
-```c
+```
 CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT
 __opencl_c_ext_fp32_global_atomic_add
 atomic_fetch_add_explicit
+atomic_xchg
+atomic_cmpxchg
 ```
 
 ## Command Line Options
@@ -31,6 +36,7 @@ atomic_fetch_add_explicit
 | `-d <index>` | 0 | Specify the index of the OpenCL device in the platform to execute on the sample on.
 | `-p <index>` | 0 | Specify the index of the OpenCL platform to execute the sample on.
 | `-i <number>` | 16 | Specify the number of iterations to execute.
-| `--gwx <number>` | 16384 | Specify the global work size to execute, which is also the number of floating-point atomics to perform.
+| `--gwx <number>` | 16384 | Specify the global work size, which is also the number of floating-point atomics to perform.
 | `-e` | N/A | Unconditionally use the emulated floating-point atomic add.
-| `-e` | N/A | Check intermediate results for correctness, requires non-emulated atomics, requires adding a positive value.
+| `-s` | N/A | Unconditionally use the slower and safer emulated floating-point atomic add.
+| `-e` | N/A | Check intermediate results for correctness, unsupported for the faster emulated atomics, requires adding a positive value.

--- a/samples/16_floatatomics/README.md
+++ b/samples/16_floatatomics/README.md
@@ -2,13 +2,27 @@
 
 ## Sample Purpose
 
-TODO
+This is an advanced sample that demonstrates how to do atomic floating-point atomic addition in a kernel.
+The most standard way to perform floating-point atomic addition uses the [cl_ext_float_atomics](https://registry.khronos.org/OpenCL/extensions/ext/cl_ext_float_atomics.html) extension.
+This extension adds device queries and built-in functions to optionally support floating-point atomic add, min, max, load, and store on 16-bit, 32-bit, and 64-bit floating-point types.
+When the `cl_ext_float_atomics` extenison is supported, and 32-bit floating point atomic adds are supported, this sample will use the built-in functions added by this extension.
 
-Inspired by: https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html
+This sample also fallback implentations when the `cl_ext_float_atomics` extension is not supported:
+
+* For NVIDIA GPUs, this sample includes a fallback that does the floating-point atomic add using inline PTX assembly language.
+* For AMD GPUs, this sample includes a fallback that calls a compiler intrinsic to do the floating-point atomic add.
+* For other devices, this sample includes a fallback that emulates the floating-point atomic add using 32-bit `atomic_xchg` functions.
+This fallback implementation cannot reliably return the "old" value that was in memory before performing the atomic add, so it is unsuitable for all usages, but it does work for some important uses-cases, such as reductions.
+
+This sample was inspired by the blog post: https://pipinspace.github.io/blog/atomic-float-addition-in-opencl.html
 
 ## Key APIs and Concepts
 
-TODO
+```c
+CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT
+__opencl_c_ext_fp32_global_atomic_add
+atomic_fetch_add_explicit
+```
 
 ## Command Line Options
 
@@ -17,5 +31,6 @@ TODO
 | `-d <index>` | 0 | Specify the index of the OpenCL device in the platform to execute on the sample on.
 | `-p <index>` | 0 | Specify the index of the OpenCL platform to execute the sample on.
 | `-i <number>` | 16 | Specify the number of iterations to execute.
-| `--gwx <number>` | 1024 | Specify the global work size to execute, which is also the number of floating-point atomics to perform.
+| `--gwx <number>` | 16384 | Specify the global work size to execute, which is also the number of floating-point atomics to perform.
 | `-e` | N/A | Unconditionally use the emulated floating-point atomic add.
+| `-e` | N/A | Check intermediate results for correctness, requires non-emulated atomics, requires adding a positive value.

--- a/samples/16_floatatomics/main.cpp
+++ b/samples/16_floatatomics/main.cpp
@@ -259,7 +259,8 @@ int main(
             }
 
             if (mismatches) {
-                printf("Intermediate Results Validation: Found %zu mismatches / %zu values!!!\n", mismatches, gwx);
+                printf("Intermediate Results Validation: Found %zu mismatches / %zu values!!!\n",
+                    mismatches, gwx);
             } else {
                 printf("Intermediate Results Validation: Success.\n");
             }

--- a/samples/16_floatatomics/main.cpp
+++ b/samples/16_floatatomics/main.cpp
@@ -177,8 +177,7 @@ int main(
         commandQueue.finish();
 
         auto start = std::chrono::system_clock::now();
-        for( size_t i = 0; i < iterations; i++ )
-        {
+        for (size_t i = 0; i < iterations; i++) {
             cl_float zero = 0.0f;
             commandQueue.enqueueFillBuffer(
                 dst,
@@ -200,6 +199,11 @@ int main(
 
     // basic validation
     {
+        cl_float check = 0.0f;
+        for (size_t i = 0; i < gwx; i++) {
+            check += 1.0f;
+        }
+
         cl_float result = 0.0f;
         commandQueue.enqueueReadBuffer(
             dst,
@@ -207,8 +211,8 @@ int main(
             0,
             sizeof(result),
             &result);
-        if (result != (float)gwx) {
-            printf("Error: expected %f, got %f!\n", (float)gwx, result);
+        if (result != check) {
+            printf("Error: expected %f, got %f!\n", check, result);
         } else {
             printf("Basic Validation: Success.\n");
         }

--- a/samples/16_floatatomics/main.cpp
+++ b/samples/16_floatatomics/main.cpp
@@ -1,5 +1,5 @@
 /*
-// Copyright (c) 2019-2024 Ben Ashbaugh
+// Copyright (c) 2024 Ben Ashbaugh
 //
 // SPDX-License-Identifier: MIT
 */

--- a/samples/16_floatatomics/main.cpp
+++ b/samples/16_floatatomics/main.cpp
@@ -102,7 +102,7 @@ int main(
         op.add<popl::Value<size_t>>("i", "iterations", "Iterations", iterations, &iterations);
         op.add<popl::Value<size_t>>("", "gwx", "Global Work Size X AKA Number of Atomics", gwx, &gwx);
         op.add<popl::Switch>("e", "emulate", "Unconditionally Emulate Float Atomics", &emulate);
-        op.add<popl::Switch>("s", "slow-emulate", "Unconditionally Emulate Float Atomics with Return Support", &slowEmulate);
+        op.add<popl::Switch>("s", "slow-emulate", "Unconditionally Emulate Float Atomics (slowly and safely)", &slowEmulate);
         op.add<popl::Switch>("c", "check", "Check Intermediate Results", &check);
 
         bool printUsage = false;

--- a/samples/16_floatatomics/main.cpp
+++ b/samples/16_floatatomics/main.cpp
@@ -1,0 +1,205 @@
+/*
+// Copyright (c) 2019-2024 Ben Ashbaugh
+//
+// SPDX-License-Identifier: MIT
+*/
+
+#include <popl/popl.hpp>
+
+#include <CL/opencl.hpp>
+
+#include <chrono>
+#include <cinttypes>
+
+#include "util.hpp"
+
+static const char kernelString[] = R"CLC(
+inline float atomic_add_f(volatile global float* addr, float val)
+{
+    #if defined(__opencl_c_ext_fp32_global_atomic_add) && !defined(EMULATE)
+        //#pragma message("using cl_ext_float_atomics")
+        return atomic_fetch_add_explicit((volatile global atomic_float*)addr, val, memory_order_relaxed);
+    #elif defined(cl_nv_pragma_unroll) && !defined(EMULATE)
+        //#pragma message("using PTX atomics")
+        float ret; asm volatile("atom.global.add.f32 %0,[%1],%2;":"=f"(ret):"l"(addr),"f"(val):"memory");
+        return ret;
+    #else // fallback, see: https://forums.developer.nvidia.com/t/atomicadd-float-float-atomicmul-float-float/14639/7
+        //#pragma message("using emulated float atomics")
+        float ret = atomic_xchg(addr, 0.0f);
+        float old = ret + val;
+        while((old = atomic_xchg(addr, old)) != 0.0f) {
+            old = atomic_xchg(addr, 0.0f) + old;
+        }
+        return ret;
+    #endif
+}
+
+kernel void FloatAtomicTest(global float* dst)
+{
+    atomic_add_f(dst, 1.0f);
+}
+)CLC";
+
+static void PrintFloatAtomicCapabilities(
+    cl_device_fp_atomic_capabilities_ext caps )
+{
+    if (caps & CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT ) printf("\t\tCL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT\n");
+    if (caps & CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT        ) printf("\t\tCL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT\n");
+    if (caps & CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT    ) printf("\t\tCL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT\n");
+    if (caps & CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT  ) printf("\t\tCL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT\n");
+    if (caps & CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT         ) printf("\t\tCL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT\n");
+    if (caps & CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT     ) printf("\t\tCL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT\n");
+
+    cl_device_command_buffer_capabilities_khr extra = caps & ~(
+        CL_DEVICE_GLOBAL_FP_ATOMIC_LOAD_STORE_EXT |
+        CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT |
+        CL_DEVICE_GLOBAL_FP_ATOMIC_MIN_MAX_EXT |
+        CL_DEVICE_LOCAL_FP_ATOMIC_LOAD_STORE_EXT |
+        CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT |
+        CL_DEVICE_LOCAL_FP_ATOMIC_MIN_MAX_EXT );
+    if (extra) {
+        printf("\t\t(Unknown capability: %016" PRIx64 ")\n", extra);
+    }
+}
+
+int main(
+    int argc,
+    char** argv )
+{
+    int platformIndex = 0;
+    int deviceIndex = 0;
+
+    size_t iterations = 16;
+    size_t gwx = 1024 * 1024;
+
+    bool emulate = false;
+
+    {
+        popl::OptionParser op("Supported Options");
+        op.add<popl::Value<int>>("p", "platform", "Platform Index", platformIndex, &platformIndex);
+        op.add<popl::Value<int>>("d", "device", "Device Index", deviceIndex, &deviceIndex);
+        op.add<popl::Value<size_t>>("i", "iterations", "Iterations", iterations, &iterations);
+        op.add<popl::Value<size_t>>("", "gwx", "Global Work Size X AKA Number of Atomics", gwx, &gwx);
+        op.add<popl::Switch>("e", "emulate", "Unconditionally Emulate Float Atomics", &emulate);
+
+        bool printUsage = false;
+        try {
+            op.parse(argc, argv);
+        } catch (std::exception& e) {
+            fprintf(stderr, "Error: %s\n\n", e.what());
+            printUsage = true;
+        }
+
+        if (printUsage || !op.unknown_options().empty() || !op.non_option_args().empty()) {
+            fprintf(stderr,
+                "Usage: floatatomics [options]\n"
+                "%s", op.help().c_str());
+            return -1;
+        }
+    }
+
+    std::vector<cl::Platform> platforms;
+    cl::Platform::get(&platforms);
+
+    printf("Running on platform: %s\n",
+        platforms[platformIndex].getInfo<CL_PLATFORM_NAME>().c_str() );
+
+    std::vector<cl::Device> devices;
+    platforms[platformIndex].getDevices(CL_DEVICE_TYPE_ALL, &devices);
+
+    printf("Running on device: %s\n",
+        devices[deviceIndex].getInfo<CL_DEVICE_NAME>().c_str() );
+
+    if (checkDeviceForExtension(devices[deviceIndex], CL_EXT_FLOAT_ATOMICS_EXTENSION_NAME)) {
+        printf("Device supports " CL_EXT_FLOAT_ATOMICS_EXTENSION_NAME ".\n");
+
+        cl_device_fp_atomic_capabilities_ext spcaps =
+            devices[deviceIndex].getInfo<CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT>();
+        printf("CL_DEVICE_SINGLE_FP_ATOMIC_CAPABILITIES_EXT:\n");
+        PrintFloatAtomicCapabilities(spcaps);
+
+        cl_device_fp_atomic_capabilities_ext dpcaps =
+            devices[deviceIndex].getInfo<CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT>();
+        printf("CL_DEVICE_DOUBLE_FP_ATOMIC_CAPABILITIES_EXT:\n");
+        PrintFloatAtomicCapabilities(dpcaps);
+
+        cl_device_fp_atomic_capabilities_ext hpcaps =
+            devices[deviceIndex].getInfo<CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT>();
+        printf("CL_DEVICE_HALF_FP_ATOMIC_CAPABILITIES_EXT:\n");
+        PrintFloatAtomicCapabilities(hpcaps);
+
+        if (spcaps & CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT == 0) {
+            printf("Device does not support fp32 atomic add.\n");
+        }
+    } else {
+        printf("Device does not support " CL_EXT_FLOAT_ATOMICS_EXTENSION_NAME ".\n");
+    }
+
+    cl::Context context{devices[deviceIndex]};
+    cl::CommandQueue commandQueue{context, devices[deviceIndex]};
+
+    cl::Program program{ context, kernelString };
+    std::string buildOptions = "-cl-std=CL3.0";
+
+    if (emulate) {
+        printf("Forcing emulation.\n");
+        buildOptions += " -DEMULATE";
+    }
+
+    program.build(buildOptions);
+    cl::Kernel kernel = cl::Kernel{ program, "FloatAtomicTest" };
+
+    cl::Buffer deviceMemDst = cl::Buffer{
+        context,
+        CL_MEM_READ_WRITE,
+        sizeof(cl_float) };
+
+    // execution
+    {
+        kernel.setArg(0, deviceMemDst);
+
+        // Ensure the queue is empty and no processing is happening
+        // on the device before starting the timer.
+        commandQueue.finish();
+
+        auto start = std::chrono::system_clock::now();
+        for( size_t i = 0; i < iterations; i++ )
+        {
+            cl_float zero = 0.0f;
+            commandQueue.enqueueFillBuffer(
+                deviceMemDst,
+                zero,
+                0,
+                sizeof(zero));
+            commandQueue.enqueueNDRangeKernel(
+                kernel,
+                cl::NullRange,
+                cl::NDRange{gwx});
+        }
+
+        // Ensure all processing is complete before stopping the timer.
+        commandQueue.finish();
+
+        auto end = std::chrono::system_clock::now();
+        std::chrono::duration<float> elapsed_seconds = end - start;
+        printf("Finished in %f seconds\n", elapsed_seconds.count());
+    }
+
+    // validation
+    {
+        cl_float result = 0.0f;
+        commandQueue.enqueueReadBuffer(
+            deviceMemDst,
+            CL_TRUE,
+            0,
+            sizeof(result),
+            &result);
+        if (result != (float)gwx) {
+            printf("Error: expected %f, got %f!\n", (float)gwx, result);
+        } else {
+            printf("Success.\n");
+        }
+    }
+
+    return 0;
+}

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -75,6 +75,7 @@ add_subdirectory( 05_spirvkernelfromfile )
 add_subdirectory( 06_ndrangekernelfromfile )
 
 add_subdirectory( 10_queueexperiments )
+add_subdirectory( 16_floatatomics )
 
 set(BUILD_EXTENSION_SAMPLES TRUE)
 if(NOT TARGET OpenCLExt)


### PR DESCRIPTION
Adds a sample demonstrating how to use floating-point atomics in an OpenCL kernel.