### PR TITLE
support mixed in-order recording and replay

### DIFF
--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -30,8 +30,6 @@ SLayerContext& getLayerContext(void)
     return c;
 }
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
-
 // Supported mutable dispatch capabilities.
 // Right now, all capabilities are supported.
 const cl_mutable_dispatch_fields_khr g_MutableDispatchCaps =
@@ -40,15 +38,6 @@ const cl_mutable_dispatch_fields_khr g_MutableDispatchCaps =
     CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR |
     CL_MUTABLE_DISPATCH_ARGUMENTS_KHR |
     CL_MUTABLE_DISPATCH_EXEC_INFO_KHR;
-
-#if !defined(CL_MUTABLE_DISPATCH_ASSERTS_KHR)
-typedef cl_bitfield         cl_mutable_dispatch_asserts_khr;
-#define CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR  0x12B7
-#define CL_MUTABLE_DISPATCH_ASSERTS_KHR                 0x12B8
-#define CL_MUTABLE_DISPATCH_ASSERT_NO_ADDITIONAL_WORK_GROUPS_KHR (1 << 0)
-#endif // !defined(CL_MUTABLE_DISPATCH_ASSERTS_KHR)
-
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
 typedef struct _cl_mutable_command_khr
 {
@@ -67,7 +56,6 @@ typedef struct _cl_mutable_command_khr
         return Type;
     }
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     virtual cl_int  getInfo(
         cl_mutable_command_info_khr param_name,
         size_t param_value_size,
@@ -154,7 +142,6 @@ typedef struct _cl_mutable_command_khr
 
         return CL_INVALID_VALUE;
     }
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
     void addDependencies(
         cl_uint num_sync_points,
@@ -825,7 +812,6 @@ struct NDRangeKernel : Command
         g_pNextDispatch->clReleaseKernel(original_kernel);
     }
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     cl_int  getInfo(
         cl_mutable_command_info_khr param_name,
         size_t param_value_size,
@@ -1072,7 +1058,6 @@ struct NDRangeKernel : Command
 
         return CL_SUCCESS;
     }
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
     int playback(
         cl_command_queue queue,
@@ -1095,11 +1080,9 @@ struct NDRangeKernel : Command
     cl_kernel original_kernel = nullptr;
     cl_kernel kernel = nullptr;
     cl_uint work_dim = 0;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     cl_mutable_dispatch_fields_khr mutableFields = 0;
     cl_mutable_dispatch_asserts_khr mutableAsserts = 0;
     size_t  numWorkGroups = 0;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
     std::vector<cl_command_properties_khr> properties;
     std::vector<size_t> global_work_offset;
     std::vector<size_t> global_work_size;
@@ -1148,9 +1131,7 @@ typedef struct _cl_command_buffer_khr
 
         ptrdiff_t numProperties = 0;
         cl_command_buffer_flags_khr flags = 0;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
         cl_mutable_dispatch_asserts_khr mutableDispatchAsserts = 0;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
         if( num_queues != 1 || queues == NULL )
         {
@@ -1179,7 +1160,6 @@ typedef struct _cl_command_buffer_khr
                         check += 2;
                     }
                     break;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
                 case CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR:
                     if( found_CL_COMMAND_BUFFER_MUTABLE_DISPATCH_ASSERTS_KHR )
                     {
@@ -1192,7 +1172,6 @@ typedef struct _cl_command_buffer_khr
                         check += 2;
                     }
                     break;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
                 default:
                     errorCode = CL_INVALID_VALUE;
                     break;
@@ -1205,11 +1184,7 @@ typedef struct _cl_command_buffer_khr
             errcode_ret[0] = errorCode;
         }
         if( errorCode == CL_SUCCESS) {
-            cmdbuf = new _cl_command_buffer_khr(flags
-#if defined(cl_khr_command_buffer_mutable_dispatch)
-                , mutableDispatchAsserts
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
-            );
+            cmdbuf = new _cl_command_buffer_khr(flags, mutableDispatchAsserts);
             cmdbuf->Queues.reserve(num_queues);
             cmdbuf->Queues.insert(
                 cmdbuf->Queues.begin(),
@@ -1265,9 +1240,7 @@ typedef struct _cl_command_buffer_khr
     {
         const cl_command_buffer_flags_khr allFlags =
             CL_COMMAND_BUFFER_SIMULTANEOUS_USE_KHR |
-#if defined(cl_khr_command_buffer_mutable_dispatch)
             CL_COMMAND_BUFFER_MUTABLE_KHR |
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 #if defined(cl_khr_command_buffer_multi_device) && 0
             CL_COMMAND_BUFFER_DEVICE_SIDE_SYNC_KHR |
 #endif // defined(cl_khr_command_buffer_multi_device)
@@ -1314,12 +1287,10 @@ typedef struct _cl_command_buffer_khr
         return nullptr;
     }
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     cl_mutable_dispatch_asserts_khr getMutableDispatchAsserts() const
     {
         return MutableDispatchAsserts;
     }
-#endif
 
     cl_int  getInfo(
                 cl_command_buffer_info_khr param_name,
@@ -1586,7 +1557,6 @@ typedef struct _cl_command_buffer_khr
         return errorCode;
     }
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     cl_int  mutate(
                 cl_uint numUpdates,
                 const cl_command_buffer_update_type_khr* updateTypes,
@@ -1639,7 +1609,6 @@ typedef struct _cl_command_buffer_khr
 
         return CL_SUCCESS;
     }
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
 private:
     static constexpr cl_uint cMagic = 0x434d4442;   // "CMDB"
@@ -1649,9 +1618,8 @@ private:
     std::vector<cl_command_buffer_properties_khr>   Properties;
     cl_command_buffer_state_khr State;
     cl_command_buffer_flags_khr Flags;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     cl_mutable_dispatch_asserts_khr MutableDispatchAsserts;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
+
     std::atomic<uint32_t> RefCount;
 
     std::vector<cl_command_queue>   TestQueues;
@@ -1733,17 +1701,12 @@ private:
     }
 
     _cl_command_buffer_khr(
-            cl_command_buffer_flags_khr flags
-#if defined(cl_khr_command_buffer_mutable_dispatch)
-            , cl_mutable_dispatch_asserts_khr mutableDispatchAsserts
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
-            ) :
+            cl_command_buffer_flags_khr flags,
+            cl_mutable_dispatch_asserts_khr mutableDispatchAsserts) :
         Magic(cMagic),
         State(CL_COMMAND_BUFFER_STATE_RECORDING_KHR),
         Flags(flags),
-#if defined(cl_khr_command_buffer_mutable_dispatch)
         MutableDispatchAsserts(mutableDispatchAsserts),
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
         RefCount(1),
         NextSyncPoint(1) {}
 } CommandBuffer;
@@ -1776,10 +1739,8 @@ std::unique_ptr<NDRangeKernel> NDRangeKernel::create(
     errorCode = CL_SUCCESS;
 
     ptrdiff_t numProperties = 0;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     cl_mutable_dispatch_fields_khr mutableFields = g_MutableDispatchCaps;
     cl_mutable_dispatch_asserts_khr mutableAsserts = 0;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
     if( properties )
     {
@@ -1791,7 +1752,6 @@ std::unique_ptr<NDRangeKernel> NDRangeKernel::create(
             cl_int  property = (cl_int)check[0];
             switch( property )
             {
-#if defined(cl_khr_command_buffer_mutable_dispatch)
             case CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR:
                 if( found_CL_MUTABLE_DISPATCH_UPDATABLE_FIELDS_KHR )
                 {
@@ -1818,7 +1778,6 @@ std::unique_ptr<NDRangeKernel> NDRangeKernel::create(
                     check += 2;
                 }
                 break;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
             default:
                 errorCode = CL_INVALID_VALUE;
                 return nullptr;
@@ -1827,7 +1786,6 @@ std::unique_ptr<NDRangeKernel> NDRangeKernel::create(
         numProperties = check - properties + 1;
     }
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     if( local_work_size == nullptr )
     {
         const auto mutableAssertsCmdBuf = cmdbuf->getMutableDispatchAsserts();
@@ -1838,7 +1796,6 @@ std::unique_ptr<NDRangeKernel> NDRangeKernel::create(
             return nullptr;
         }
     }
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
     auto command = std::unique_ptr<NDRangeKernel>(
         new NDRangeKernel(cmdbuf, queue));
@@ -1847,14 +1804,12 @@ std::unique_ptr<NDRangeKernel> NDRangeKernel::create(
     command->kernel = g_pNextDispatch->clCloneKernel(kernel, NULL);
     command->work_dim = work_dim;
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     command->mutableFields = mutableFields;
     command->mutableAsserts = mutableAsserts;
     command->numWorkGroups = getNumWorkGroups(
         work_dim,
         global_work_size,
         local_work_size );
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
     command->properties.reserve(numProperties);
     command->properties.insert(
@@ -2715,12 +2670,6 @@ cl_int CL_API_CALL clCommandNDRangeKernelKHR_EMU(
     {
         return errorCode;
     }
-#if !defined(cl_khr_command_buffer_mutable_dispatch)
-    if( mutable_handle != nullptr )
-    {
-        return CL_INVALID_VALUE;
-    }
-#endif // !defined(cl_khr_command_buffer_mutable_dispatch)
     if( cl_command_queue testQueue = cmdbuf->getTestQueue() )
     {
         if( cl_int errorCode = g_pNextDispatch->clEnqueueNDRangeKernel(
@@ -2808,8 +2757,6 @@ cl_command_buffer_khr CL_API_CALL clRemapCommandBufferKHR_EMU(
 
 #endif // defined(cl_khr_command_buffer_multi_device)
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // cl_khr_command_buffer_mutable_dispatch
@@ -2855,8 +2802,6 @@ cl_int CL_API_CALL clGetMutableCommandInfoKHR_EMU(
         param_value,
         param_value_size_ret);
 }
-
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
 bool clGetDeviceInfo_override(
     cl_device_id device,
@@ -2909,10 +2854,8 @@ bool clGetDeviceInfo_override(
             {
                 std::string newExtensions;
                 newExtensions += CL_KHR_COMMAND_BUFFER_EXTENSION_NAME;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
                 newExtensions += ' ';
                 newExtensions += CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
                 std::string oldExtensions(deviceExtensions.data());
 
@@ -3002,7 +2945,6 @@ bool clGetDeviceInfo_override(
 
                     extension.version = version_cl_khr_command_buffer;
                 }
-#if defined(cl_khr_command_buffer_mutable_dispatch)
                 {
                     extensions.emplace_back();
                     cl_name_version& extension = extensions.back();
@@ -3012,7 +2954,6 @@ bool clGetDeviceInfo_override(
 
                     extension.version = version_cl_khr_command_buffer_mutable_dispatch;
                 }
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
                 auto ptr = (cl_name_version*)param_value;
                 cl_int errorCode = writeVectorToMemory(
@@ -3115,7 +3056,6 @@ bool clGetDeviceInfo_override(
             return true;
         }
         break;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     case CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR:
         {
             cl_mutable_dispatch_fields_khr caps =
@@ -3135,7 +3075,6 @@ bool clGetDeviceInfo_override(
             return true;
         }
         break;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
     default: break;
     }
 
@@ -3264,10 +3203,8 @@ bool clGetPlatformInfo_override(
             {
                 std::string newExtensions;
                 newExtensions += CL_KHR_COMMAND_BUFFER_EXTENSION_NAME;
-#if defined(cl_khr_command_buffer_mutable_dispatch)
                 newExtensions += ' ';
                 newExtensions += CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME;
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
                 std::string oldExtensions(platformExtensions.data());
 
@@ -3357,7 +3294,6 @@ bool clGetPlatformInfo_override(
 
                     extension.version = version_cl_khr_command_buffer;
                 }
-#if defined(cl_khr_command_buffer_mutable_dispatch)
                 {
                     extensions.emplace_back();
                     cl_name_version& extension = extensions.back();
@@ -3367,7 +3303,6 @@ bool clGetPlatformInfo_override(
 
                     extension.version = version_cl_khr_command_buffer_mutable_dispatch;
                 }
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
                 auto ptr = (cl_name_version*)param_value;
                 cl_int errorCode = writeVectorToMemory(

--- a/layers/10_cmdbufemu/emulate.cpp
+++ b/layers/10_cmdbufemu/emulate.cpp
@@ -19,9 +19,8 @@
 
 #include "emulate.h"
 
-// TODO: bump to 0.9.7 when tests are ready.
 static constexpr cl_version version_cl_khr_command_buffer =
-    CL_MAKE_VERSION(0, 9, 6);
+    CL_MAKE_VERSION(0, 9, 7);
 static constexpr cl_version version_cl_khr_command_buffer_mutable_dispatch =
     CL_MAKE_VERSION(0, 9, 3);
 

--- a/layers/10_cmdbufemu/emulate.h
+++ b/layers/10_cmdbufemu/emulate.h
@@ -217,8 +217,6 @@ cl_command_buffer_khr CL_API_CALL clRemapCommandBufferKHR_EMU(
 
 #endif // defined(cl_khr_command_buffer_multi_device)
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
-
 cl_int CL_API_CALL clUpdateMutableCommandsKHR_EMU(
     cl_command_buffer_khr command_buffer,
     cl_uint num_configs,
@@ -231,8 +229,6 @@ cl_int CL_API_CALL clGetMutableCommandInfoKHR_EMU(
     size_t param_value_size,
     void* param_value,
     size_t* param_value_size_ret);
-
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Override Functions

--- a/layers/10_cmdbufemu/main.cpp
+++ b/layers/10_cmdbufemu/main.cpp
@@ -155,10 +155,8 @@ clGetExtensionFunctionAddressForPlatform_layer(
     CHECK_RETURN_EXTENSION_FUNCTION( clRemapCommandBufferKHR );
 #endif
 
-#if defined(cl_khr_command_buffer_mutable_dispatch)
     CHECK_RETURN_EXTENSION_FUNCTION( clUpdateMutableCommandsKHR );
     CHECK_RETURN_EXTENSION_FUNCTION( clGetMutableCommandInfoKHR );
-#endif // defined(cl_khr_command_buffer_mutable_dispatch)
 
     return g_pNextDispatch->clGetExtensionFunctionAddressForPlatform(
         platform,


### PR DESCRIPTION
see: https://github.com/KhronosGroup/OpenCL-Docs/pull/1292

Adds support for recording a command buffer with an in-order queue, and replaying it with an out-of-order queue.  In this case, explicit dependencies are added (via command queue barriers), to enforce the in-order behavior.

I will keep this as a draft until the spec changes are merged, at which time the reported extension version will need to be updated.