### PR TITLE
ensure nbody epsilon is a float constant

### DIFF
--- a/samples/opengl/01_nbodygl/main.cpp
+++ b/samples/opengl/01_nbodygl/main.cpp
@@ -57,7 +57,7 @@ __kernel void nbody_step(
     const float G = 1.0f / numBodies;
     const float dampen = 0.90f;
     const float deltaTime = 0.005f;
-    const float epsilon = 1e-3;
+    const float epsilon = 1e-3f;
 
     float3 myPos = pos[get_global_id(0)].xyz;
     float myMass = pos[get_global_id(0)].w;

--- a/samples/vulkan/01_nbodyvk/main.cpp
+++ b/samples/vulkan/01_nbodyvk/main.cpp
@@ -48,7 +48,7 @@ __kernel void nbody_step(
     const float G = 1.0f / numBodies;
     const float dampen = 0.90f;
     const float deltaTime = 0.005f;
-    const float epsilon = 1e-3;
+    const float epsilon = 1e-3f;
 
     float3 myPos = pos[get_global_id(0)].xyz;
     float myMass = pos[get_global_id(0)].w;


### PR DESCRIPTION
Use an explicit float suffix to ensure that the nbody epsilon constant is considered a float constant.

This fixes a kernel build warning on some devices.