### PR TITLE
query the right object for the compile log

### DIFF
--- a/samples/06_ndrangekernelfromfile/main.cpp
+++ b/samples/06_ndrangekernelfromfile/main.cpp
@@ -107,7 +107,7 @@ int main(
             compileOptions.empty() ? "(none)" : compileOptions.c_str() );
         cl::Program object{ context, kernelString };
         object.compile(compileOptions.c_str());
-        for( auto& device : program.getInfo<CL_PROGRAM_DEVICES>() )
+        for( auto& device : object.getInfo<CL_PROGRAM_DEVICES>() )
         {
             printf("Program compile log for device %s:\n",
                 device.getInfo<CL_DEVICE_NAME>().c_str() );


### PR DESCRIPTION
When querying the compile log, we need to query the intermediate program object, not the final program object.

The final program object has not been created yet, so it doesn't have any devices associated with it yet.