### PR TITLE
add a missing SPIR-V queries check for the extended debug info extension

### DIFF
--- a/layers/12_spirvqueriesemu/emulate.cpp
+++ b/layers/12_spirvqueriesemu/emulate.cpp
@@ -406,6 +406,11 @@ private:
                     deviceInfo.Capabilities.push_back(spv::CapabilityImageMipmap);
                 }
 
+                // Required for devices supporting cl_khr_spirv_extended_debug_info.
+                if (checkStringForExtension(deviceExtensions.c_str(), "cl_khr_spirv_extended_debug_info")) {
+                    deviceInfo.ExtendedInstructionSets.push_back("OpenCL.DebugInfo.100");
+                }
+
                 // Required for devices supporting cl_khr_spirv_linkonce_odr.
                 if (checkStringForExtension(deviceExtensions.c_str(), "cl_khr_spirv_linkonce_odr")) {
                     deviceInfo.Extensions.push_back("SPV_KHR_linkonce_odr");


### PR DESCRIPTION
When the OpenCL extension [cl_khr_spirv_extended_debug_info](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#cl_khr_spirv_extended_debug_info) is supported, the `OpenCL.DebugInfo.100` SPIR-V extended instruction set must also be supported.