### PR TITLE
add a few additional missing SPIR-V query cases

### DIFF
--- a/layers/12_spirvqueriesemu/emulate.cpp
+++ b/layers/12_spirvqueriesemu/emulate.cpp
@@ -343,13 +343,15 @@ private:
                 }
 
                 // Required for OpenCL 2.2 devices.
-                if (deviceVersion == CL_MAKE_VERSION(2, 2, 0)) {
+                if (deviceILVersion.find("SPIR-V_1.1") != std::string::npos &&
+                    deviceVersion == CL_MAKE_VERSION(2, 2, 0)) {
                     deviceInfo.Capabilities.push_back(spv::CapabilityPipeStorage);
                 }
 
                 // Required for OpenCL 2.2, or OpenCL 3.0 devices supporting sub-groups.
-                if (deviceVersion == CL_MAKE_VERSION(2, 2, 0) ||
-                    (deviceVersion >= CL_MAKE_VERSION(3, 0, 0) && deviceMaxNumSubGroups != 0)) {
+                if (deviceILVersion.find("SPIR-V_1.1") != std::string::npos &&
+                    (deviceVersion == CL_MAKE_VERSION(2, 2, 0) ||
+                     (deviceVersion >= CL_MAKE_VERSION(3, 0, 0) && deviceMaxNumSubGroups != 0))) {
                     deviceInfo.Capabilities.push_back(spv::CapabilitySubgroupDispatch);
                 }
 
@@ -497,7 +499,7 @@ private:
                 // Required for devices supporting cl_ext_float_atomics and fp64 atomic adds.
                 if (checkStringForExtension(deviceExtensions.c_str(), "cl_ext_float_atomics") &&
                     (deviceFp64AtomicCapabilities & (CL_DEVICE_GLOBAL_FP_ATOMIC_ADD_EXT | CL_DEVICE_LOCAL_FP_ATOMIC_ADD_EXT))) {
-                    deviceInfo.Capabilities.push_back(spv::CapabilityAtomicFloat64MinMaxEXT);
+                    deviceInfo.Capabilities.push_back(spv::CapabilityAtomicFloat64AddEXT);
                 }
 
                 // Required for devices supporting cl_ext_float_atomics and fp64 atomic min and max.


### PR DESCRIPTION
* Adds a missing check for SPIR-V 1.1 for the PipeStorage and SubgroupDispatch capabilities.
* Fix a copy-paste error resulting in AtomicFloat64AddEXT not being properly reported in some cases.