### PR TITLE
add the ability to use an empty kernel for command buffer profiling

### DIFF
--- a/layers/10_cmdbufemu/README.md
+++ b/layers/10_cmdbufemu/README.md
@@ -33,6 +33,7 @@ The following environment variables can modify the behavior of the command buffe
 | Environment Variable | Behavior |  Example Format |
 |----------------------|----------|-----------------|
 | `CMDBUFEMU_EnhancedErrorChecking` | Enables additional error checking when commands are added to a command buffer using a command buffer "test queue".  By default, the additional error checking is disabled. | `export CMDBUFEMU_EnhancedErrorChecking=1`<br/><br/>`set CMDBUFEMU_EnhancedErrorChecking=1` |
+| `CMDBUFEMU_KernelForProfiling` | Enables use of an empty kernel for event profiling instead of event profiling on a command-queue barrier.  By default, to minimize overhead, the empty kernel is not used. | `export CMDBUFEMU_KernelForProfiling=1`<br/><br/>`set CMDBUFEMU_KernelForProfiling=1` |
 
 ## Known Limitations
 

--- a/layers/10_cmdbufemu/emulate.h
+++ b/layers/10_cmdbufemu/emulate.h
@@ -10,6 +10,7 @@
 #include <map>
 
 extern bool g_EnhancedErrorChecking;
+extern bool g_KernelForProfiling;
 
 extern const struct _cl_icd_dispatch* g_pNextDispatch;
 

--- a/layers/10_cmdbufemu/main.cpp
+++ b/layers/10_cmdbufemu/main.cpp
@@ -34,6 +34,11 @@
 
 bool g_EnhancedErrorChecking = false;
 
+// Using kernels for profiling can fix issues with some implementations
+// that do not properly support event profiling on barrkers.
+
+bool g_KernelForProfiling = false;
+
 const struct _cl_icd_dispatch* g_pNextDispatch = NULL;
 
 static cl_int CL_API_CALL
@@ -283,6 +288,7 @@ CL_API_ENTRY cl_int CL_API_CALL clInitLayer(
     _init_dispatch();
 
     getControl("CMDBUFEMU_EnhancedErrorChecking", g_EnhancedErrorChecking);
+    getControl("CMDBUFEMU_KernelForProfiling", g_KernelForProfiling);
 
     g_pNextDispatch = target_dispatch;
 


### PR DESCRIPTION
The command buffer emulation layer currently implements event profiling by tracking event profiling on command-queue barriers before and after command-buffer content, but some implementations do not properly implement event profiling on barriers.  As a workaround for these implementations, track event profiling on an empty kernel immediately after the command-queue barriers instead.

Because it is less efficient to use the empty kernel for event profiling (the current implementation requires a kernel compilation per command-buffer, in addition to the additional runtime cost associated with the empty kernel every time the command buffer is executed), this codepath is disabled by default, but may be enabled with an environment variable.