### PR TITLE
Lock USVM entry-points

### DIFF
--- a/layers/99_svmplusplus/emulate.cpp
+++ b/layers/99_svmplusplus/emulate.cpp
@@ -21,9 +21,6 @@
 
 #include "emulate.h"
 
-// Locks entry-points for concurrent threads doing allocation/free
-static std::mutex Mutex;
-
 static constexpr cl_version version_cl_khr_unified_svm =
     CL_MAKE_VERSION(0, 2, 0);
 
@@ -334,6 +331,8 @@ struct SLayerContext
         EventMap.erase(event);
     }
 
+    // Locked on thread-safe CL entry-points
+    static std::mutex Mutex;
 private:
     void getSVMTypesForPlatform(cl_platform_id platform)
     {
@@ -506,6 +505,8 @@ private:
     std::map<cl_event, SEventInfo> EventMap;
 };
 
+std::mutex SLayerContext::Mutex;
+
 SLayerContext& getLayerContext(void)
 {
     static SLayerContext c;
@@ -657,7 +658,7 @@ void* CL_API_CALL clSVMAllocWithPropertiesKHR_EMU(
     size_t size,
     cl_int* errcode_ret)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     cl_platform_id platform = getPlatform(context);
     const auto& USMFuncs = getLayerContext().getUSMFuncs(platform);
 
@@ -796,7 +797,7 @@ cl_int CL_API_CALL clSVMFreeWithPropertiesKHR_EMU(
     cl_svm_free_flags_khr flags,
     void* ptr)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     if (ptr == nullptr) {
         return CL_SUCCESS;
     }
@@ -830,7 +831,7 @@ cl_int CL_API_CALL clGetSVMSuggestedTypeIndexKHR_EMU(
     size_t size,
     cl_uint* suggested_svm_type_index)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     if (suggested_svm_type_index == nullptr) {
         return CL_INVALID_VALUE;
     }
@@ -894,7 +895,7 @@ cl_int CL_API_CALL clGetSVMPointerInfoKHR_EMU(
     void* param_value,
     size_t* param_value_size_ret)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     const void* base = nullptr;
     SAllocInfo allocInfo;
     getLayerContext().findAllocInfo(context, ptr, base, allocInfo);
@@ -968,7 +969,7 @@ cl_int CL_API_CALL clGetDeviceInfo_override(
     void* param_value,
     size_t* param_value_size_ret)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     switch(param_name) {
     case CL_DEVICE_EXTENSIONS:
         {
@@ -1098,7 +1099,7 @@ cl_int CL_API_CALL clGetEventInfo_override(
     void* param_value,
     size_t* param_value_size_ret)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     switch(param_name) {
     case CL_EVENT_COMMAND_TYPE:
         {
@@ -1131,7 +1132,7 @@ cl_int CL_API_CALL clGetPlatformInfo_override(
     void* param_value,
     size_t* param_value_size_ret)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     switch(param_name) {
     case CL_PLATFORM_EXTENSIONS:
         {
@@ -1356,7 +1357,7 @@ void CL_API_CALL clSVMFree_override(
     cl_context context,
     void* ptr)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     if (isUSMPtr(context, ptr)) {
         cl_platform_id platform = getPlatform(context);
         const auto& USMFuncs = getLayerContext().getUSMFuncs(platform);
@@ -1380,7 +1381,7 @@ cl_int CL_API_CALL clEnqueueSVMFree_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     std::vector<void*> nonNullPtrs;
     for (cl_uint i = 0; i < num_svm_pointers; ++i) {
         if (svm_pointers[i] != nullptr) {
@@ -1409,7 +1410,7 @@ cl_int CL_API_CALL clEnqueueSVMMemcpy_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     cl_context context = getContext(command_queue);
 
     if (size == 0) {
@@ -1468,7 +1469,7 @@ cl_int CL_API_CALL clEnqueueSVMMemFill_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     cl_context context = getContext(command_queue);
 
     if (size == 0) {
@@ -1527,7 +1528,7 @@ cl_int CL_API_CALL clEnqueueSVMMigrateMem_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     // for now, just emit a marker
     cl_int ret = g_pNextDispatch->clEnqueueMarkerWithWaitList(
         command_queue,
@@ -1544,7 +1545,7 @@ cl_int CL_API_CALL clEnqueueSVMMigrateMem_override(
 cl_int CL_API_CALL clReleaseEvent_override(
     cl_event event)
 {
-    std::lock_guard<std::mutex> lock(Mutex);
+    std::lock_guard<std::mutex> lock(SLayerContext::Mutex);
     cl_uint refCount = 0;
     g_pNextDispatch->clGetEventInfo(
         event,

--- a/layers/99_svmplusplus/emulate.cpp
+++ b/layers/99_svmplusplus/emulate.cpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include <cassert>
 
@@ -19,6 +20,9 @@
 #include "layer_util.hpp"
 
 #include "emulate.h"
+
+// Locks entry-points for concurrent threads doing allocation/free
+static std::mutex Mutex;
 
 static constexpr cl_version version_cl_khr_unified_svm =
     CL_MAKE_VERSION(0, 2, 0);
@@ -500,7 +504,6 @@ private:
     std::map<cl_context, CAllocMap> AllocMaps;
 
     std::map<cl_event, SEventInfo> EventMap;
-
 };
 
 SLayerContext& getLayerContext(void)
@@ -654,6 +657,7 @@ void* CL_API_CALL clSVMAllocWithPropertiesKHR_EMU(
     size_t size,
     cl_int* errcode_ret)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     cl_platform_id platform = getPlatform(context);
     const auto& USMFuncs = getLayerContext().getUSMFuncs(platform);
 
@@ -792,6 +796,7 @@ cl_int CL_API_CALL clSVMFreeWithPropertiesKHR_EMU(
     cl_svm_free_flags_khr flags,
     void* ptr)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     if (ptr == nullptr) {
         return CL_SUCCESS;
     }
@@ -825,6 +830,7 @@ cl_int CL_API_CALL clGetSVMSuggestedTypeIndexKHR_EMU(
     size_t size,
     cl_uint* suggested_svm_type_index)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     if (suggested_svm_type_index == nullptr) {
         return CL_INVALID_VALUE;
     }
@@ -888,6 +894,7 @@ cl_int CL_API_CALL clGetSVMPointerInfoKHR_EMU(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     const void* base = nullptr;
     SAllocInfo allocInfo;
     getLayerContext().findAllocInfo(context, ptr, base, allocInfo);
@@ -961,6 +968,7 @@ cl_int CL_API_CALL clGetDeviceInfo_override(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     switch(param_name) {
     case CL_DEVICE_EXTENSIONS:
         {
@@ -1090,6 +1098,7 @@ cl_int CL_API_CALL clGetEventInfo_override(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     switch(param_name) {
     case CL_EVENT_COMMAND_TYPE:
         {
@@ -1122,6 +1131,7 @@ cl_int CL_API_CALL clGetPlatformInfo_override(
     void* param_value,
     size_t* param_value_size_ret)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     switch(param_name) {
     case CL_PLATFORM_EXTENSIONS:
         {
@@ -1346,6 +1356,7 @@ void CL_API_CALL clSVMFree_override(
     cl_context context,
     void* ptr)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     if (isUSMPtr(context, ptr)) {
         cl_platform_id platform = getPlatform(context);
         const auto& USMFuncs = getLayerContext().getUSMFuncs(platform);
@@ -1369,6 +1380,7 @@ cl_int CL_API_CALL clEnqueueSVMFree_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     std::vector<void*> nonNullPtrs;
     for (cl_uint i = 0; i < num_svm_pointers; ++i) {
         if (svm_pointers[i] != nullptr) {
@@ -1397,6 +1409,7 @@ cl_int CL_API_CALL clEnqueueSVMMemcpy_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     cl_context context = getContext(command_queue);
 
     if (size == 0) {
@@ -1455,6 +1468,7 @@ cl_int CL_API_CALL clEnqueueSVMMemFill_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     cl_context context = getContext(command_queue);
 
     if (size == 0) {
@@ -1513,6 +1527,7 @@ cl_int CL_API_CALL clEnqueueSVMMigrateMem_override(
     const cl_event* event_wait_list,
     cl_event* event)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     // for now, just emit a marker
     cl_int ret = g_pNextDispatch->clEnqueueMarkerWithWaitList(
         command_queue,
@@ -1529,6 +1544,7 @@ cl_int CL_API_CALL clEnqueueSVMMigrateMem_override(
 cl_int CL_API_CALL clReleaseEvent_override(
     cl_event event)
 {
+    std::lock_guard<std::mutex> lock(Mutex);
     cl_uint refCount = 0;
     g_pNextDispatch->clGetEventInfo(
         event,


### PR DESCRIPTION
While testing https://github.com/AdaptiveCpp/AdaptiveCpp/pull/1948 with the SYCL CTS I spotted regressions with the `marray` tests when using the usvm emulation layer ontop of Intel USM.

From my investigations the AdaptiveCpp runtime threads to do asynchronous allocations frees, and the lack of thread safety in the layers entry-points causes issues with accessing the layer context `std::map` objects. With this change the regressions disappear. I tried using the mutex in a more fine grained way as a member of the `SLayerContext`  with lock guards in the member functions, but it didn't completed fix the issue, so went for the CL entry-point level.

I don't think there's an underlying spec issue here, as OpenCL entry-points are generally thread safe by default apart from those operating on `cl_kernel`, so I didn't add the lock to `clSetKernelArgSVMPointer` or clSetKernelExecInfo`. We should probably make sure to have an OpenCL CTS test for verifying the thread safety of the alloc/free entry-points though.